### PR TITLE
카카오 로그인 오류 해결

### DIFF
--- a/src/main/java/today/seasoning/seasoning/common/config/JwtFilter.java
+++ b/src/main/java/today/seasoning/seasoning/common/config/JwtFilter.java
@@ -85,12 +85,12 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         List<String> allowedPaths = Arrays.asList(
-            "/oauth/kakao/login",
+            "/oauth/login",
             "/favicon.ico",
             "/refresh");
 
         String path = request.getRequestURI();
 
-        return allowedPaths.stream().anyMatch(path::equals);
+        return allowedPaths.stream().anyMatch(path::startsWith);
     }
 }


### PR DESCRIPTION
## 📟 연결된 이슈
close #5 

## 👷 작업한 내용
- 로그인 요청 API에 JwtFilter가 적용되어 카카오 로그인이 실패하는 문제 발생
  - 변경된 로그인 엔드포인트에 맞춰 JwtFilter의 shouldNotFilter()를 수정