### PR TITLE
아이디 조회 서비스 로직 개선

### DIFF
--- a/src/main/java/today/seasoning/seasoning/user/service/VerifyAccountIdService.java
+++ b/src/main/java/today/seasoning/seasoning/user/service/VerifyAccountIdService.java
@@ -1,9 +1,7 @@
 package today.seasoning.seasoning.user.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import today.seasoning.seasoning.common.exception.CustomException;
 import today.seasoning.seasoning.user.domain.AccountId;
 import today.seasoning.seasoning.user.domain.UserRepository;
 
@@ -13,9 +11,7 @@ public class VerifyAccountIdService {
 
     private final UserRepository userRepository;
 
-    public void verify(AccountId accountId) {
-        if(userRepository.existsByAccountId(accountId.get())) {
-            throw new CustomException(HttpStatus.CONFLICT, "아이디 중복");
-        }
+    public boolean verify(AccountId accountId) {
+        return !userRepository.existsByAccountId(accountId.get());
     }
 }


### PR DESCRIPTION
## 👷 작업한 내용
- 해당 서비스 로직의 경우, 아이디가 사용중인 상황이 예외 상황이라고 보기 힘들다
- 따라서, 아이디가 사용중인 경우 예외 발생이 아닌 false로 응답하는 것이 자연스럽다