### PR TITLE
Refactor/#13 remove unused valid property of friendship

### DIFF
--- a/src/main/java/today/seasoning/seasoning/article/service/FindMyFriendsArticlesService.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/FindMyFriendsArticlesService.java
@@ -22,15 +22,7 @@ public class FindMyFriendsArticlesService {
 	private final EntityManager entityManager;
 
 	private final String SQL = "SELECT a FROM Article a " +
-		"INNER JOIN Friendship f ON a.user.id = f.friend.id " +
-		"WHERE f.user.id = :userId " +
-		"AND f.valid = true " +
-		"AND EXISTS (" +
-		"   SELECT 1 FROM Friendship f2 " +
-		"   WHERE f2.user.id = a.user.id " +
-		"   AND f2.friend.id = :userId " +
-		"   AND f2.valid = true" +
-		") " +
+		"INNER JOIN Friendship f ON a.user.id = f.user.id AND f.friend.id = :userId " +
 		"AND a.published = true " +
 		"AND a.id < :articleId " +
 		"ORDER BY a.id DESC";

--- a/src/main/java/today/seasoning/seasoning/friendship/domain/Friendship.java
+++ b/src/main/java/today/seasoning/seasoning/friendship/domain/Friendship.java
@@ -28,21 +28,9 @@ public class Friendship extends BaseTimeEntity {
 	@JoinColumn(name = "friend_id")
 	private User friend;
 
-	@Column(nullable = false)
-	private boolean valid;
-
-	public Friendship(User user, User friend, boolean valid) {
+	public Friendship(User user, User friend) {
 		this.id = TsidUtil.createLong();
 		this.user = user;
 		this.friend = friend;
-		this.valid = valid;
-	}
-
-	public boolean isValid() {
-		return valid;
-	}
-
-	public void setValid() {
-		this.valid = true;
 	}
 }

--- a/src/main/java/today/seasoning/seasoning/friendship/domain/Friendship.java
+++ b/src/main/java/today/seasoning/seasoning/friendship/domain/Friendship.java
@@ -1,6 +1,5 @@
 package today.seasoning.seasoning.friendship.domain;
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.Id;

--- a/src/main/java/today/seasoning/seasoning/friendship/service/AcceptFriendRequestService.java
+++ b/src/main/java/today/seasoning/seasoning/friendship/service/AcceptFriendRequestService.java
@@ -39,8 +39,8 @@ public class AcceptFriendRequestService {
         }
 
         // 친구 관계 설정
-        friendshipRepository.save(new Friendship(user, requester, true));
-        friendshipRepository.save(new Friendship(requester, user, true));
+        friendshipRepository.save(new Friendship(user, requester));
+        friendshipRepository.save(new Friendship(requester, user));
 
         // 친구 요청 내역 삭제
         friendRequestRepository.deleteByFromUserIdAndToUserId(requester.getId(), user.getId());

--- a/src/test/java/today/seasoning/seasoning/friendship/service/UnfriendServiceTest.java
+++ b/src/test/java/today/seasoning/seasoning/friendship/service/UnfriendServiceTest.java
@@ -36,8 +36,8 @@ class UnfriendServiceTest {
 
     User user = new User("user", "https://test/user.jpg", "user@email.com", LoginType.KAKAO);
     User friend = new User("friend", "https://test/friend.jpg", "friend@email.com", LoginType.KAKAO);
-    Friendship userToFriendFriendship = new Friendship(user, friend, true);
-    Friendship friendToUserFriendship = new Friendship(friend, user, true);
+    Friendship userToFriendFriendship = new Friendship(user, friend);
+    Friendship friendToUserFriendship = new Friendship(friend, user);
 
     @Test
     @DisplayName("성공")


### PR DESCRIPTION
## 📟 연결된 이슈
- close #13

## 👷 작업한 내용
- Friendship 엔티티 미사용 속성 valid 제거
  - valid: 친구 요청 승인 여부를 나타내는 속성
  - 친구 요청을 별도의 FriendRequest 엔티티로 관리하여 더 이상 valid 속성은 사용되지 않는다
- valid 속성 제거에 따른 친구 기록장 목록 조회 SQL문 수정

## 🚨 참고 사항
- 사실 Friendship 테이블에서 FriendRequest 테이블을 별도로 분리한 이유가 바로 이 친구 기록장 목록 SQL문을 최적화하기 위함이었다
- 테이블 구조를 최적화하고 그에 맞춰 SQL문을 변경했을 뿐인데, 응답 시간이 **2분 56초에서 0.053초**로 줄어들었다 
- 현재도 충분히 빠른 응답시간이지만, 인덱스 및 Driving Table 변경을 통해 더욱 시간을 단축하는 것이 가능해보여 해당 [이슈](https://github.com/Seasoning-Today/backend/issues/18)는 아직 닫지 않기로 했다
## 📸 스크린샷
### 개선 전
<img width="600" alt="개선전 첫번째 페이지" src="https://github.com/Seasoning-Today/backend/assets/107951175/f4b2ed1a-f4b5-4ca4-bdde-fa672f0aa8b6">

### 개선 후
<img width="600" alt="image" src="https://github.com/Seasoning-Today/backend/assets/107951175/4abe743b-af29-4c0b-bce9-f2e76180be7f">

