### PR TITLE
예외처리 : 이미 친구인 사용자에게 친구 신청

### DIFF
--- a/src/main/java/today/seasoning/seasoning/friendship/controller/FriendshipController.java
+++ b/src/main/java/today/seasoning/seasoning/friendship/controller/FriendshipController.java
@@ -20,7 +20,7 @@ import today.seasoning.seasoning.friendship.service.AcceptFriendRequestService;
 import today.seasoning.seasoning.friendship.service.CancelFriendRequestService;
 import today.seasoning.seasoning.friendship.service.DeclineFriendRequestService;
 import today.seasoning.seasoning.friendship.service.FindUserFriendsService;
-import today.seasoning.seasoning.friendship.service.RequestFriendshipService;
+import today.seasoning.seasoning.friendship.service.SendFriendRequestService;
 import today.seasoning.seasoning.friendship.service.SearchUserService;
 import today.seasoning.seasoning.friendship.service.UnfriendService;
 
@@ -29,13 +29,13 @@ import today.seasoning.seasoning.friendship.service.UnfriendService;
 @RequiredArgsConstructor
 public class FriendshipController {
 
-    private final RequestFriendshipService requestFriendshipService;
+    private final UnfriendService unfriendService;
+    private final SearchUserService searchUserService;
     private final FindUserFriendsService findUserFriendsService;
+    private final SendFriendRequestService sendFriendRequestService;
     private final AcceptFriendRequestService acceptFriendRequestService;
     private final CancelFriendRequestService cancelFriendRequestService;
     private final DeclineFriendRequestService declineFriendRequestService;
-    private final UnfriendService unfriendService;
-    private final SearchUserService searchUserService;
 
     @RequestMapping("/add")
     public ResponseEntity<String> requestFriendship(
@@ -45,7 +45,7 @@ public class FriendshipController {
         Long userId = principal.getId();
         String requesteeAccountId = accountIdDto.getAccountId();
 
-        requestFriendshipService.doService(userId, requesteeAccountId);
+        sendFriendRequestService.doService(userId, requesteeAccountId);
 
         return ResponseEntity.ok().body("신청 완료");
     }

--- a/src/main/java/today/seasoning/seasoning/friendship/service/SendFriendRequestService.java
+++ b/src/main/java/today/seasoning/seasoning/friendship/service/SendFriendRequestService.java
@@ -17,7 +17,7 @@ import today.seasoning.seasoning.user.dto.UserProfileDto;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class RequestFriendshipService {
+public class SendFriendRequestService {
 
 	private final UserRepository userRepository;
 	private final NotificationService notificationService;

--- a/src/main/java/today/seasoning/seasoning/friendship/service/SendFriendRequestService.java
+++ b/src/main/java/today/seasoning/seasoning/friendship/service/SendFriendRequestService.java
@@ -8,6 +8,7 @@ import today.seasoning.seasoning.common.exception.CustomException;
 import today.seasoning.seasoning.common.util.EntitySerializationUtil;
 import today.seasoning.seasoning.friendship.domain.FriendRequest;
 import today.seasoning.seasoning.friendship.domain.FriendRequestRepository;
+import today.seasoning.seasoning.friendship.domain.FriendshipRepository;
 import today.seasoning.seasoning.notification.domain.NotificationType;
 import today.seasoning.seasoning.notification.service.NotificationService;
 import today.seasoning.seasoning.user.domain.User;
@@ -21,6 +22,7 @@ public class SendFriendRequestService {
 
 	private final UserRepository userRepository;
 	private final NotificationService notificationService;
+	private final FriendshipRepository friendshipRepository;
 	private final FriendRequestRepository friendRequestRepository;
 
 	public void doService(Long fromUserId, String toUserAccountId) {
@@ -37,12 +39,19 @@ public class SendFriendRequestService {
 	}
 
 	private void checkException(User fromUser, User toUser) {
+		// 자신에게 친구 요청한 경우
 		if (fromUser == toUser) {
 			throw new CustomException(HttpStatus.BAD_REQUEST, "Invalid Request");
 		}
 
+		// 이미 친구 신청을 한 경우
 		if (friendRequestRepository.existsByFromUserIdAndToUserId(fromUser.getId(), toUser.getId())) {
-			throw new CustomException(HttpStatus.CONFLICT, "Already Requested");
+			throw new CustomException(HttpStatus.CONFLICT, "Friend request already sent");
+		}
+
+		// 이미 친구인 경우
+		if (friendshipRepository.existsByUserIdAndFriendId(fromUser.getId(), toUser.getId())) {
+			throw new CustomException(HttpStatus.CONFLICT, "Already friends with this user");
 		}
 	}
 

--- a/src/test/java/today/seasoning/seasoning/friendship/service/SendFriendRequestServiceTest.java
+++ b/src/test/java/today/seasoning/seasoning/friendship/service/SendFriendRequestServiceTest.java
@@ -16,6 +16,7 @@ import org.springframework.http.HttpStatus;
 import today.seasoning.seasoning.common.enums.LoginType;
 import today.seasoning.seasoning.common.exception.CustomException;
 import today.seasoning.seasoning.friendship.domain.FriendRequestRepository;
+import today.seasoning.seasoning.friendship.domain.FriendshipRepository;
 import today.seasoning.seasoning.notification.service.NotificationService;
 import today.seasoning.seasoning.user.domain.User;
 import today.seasoning.seasoning.user.domain.UserRepository;
@@ -30,7 +31,8 @@ class SendFriendRequestServiceTest {
     NotificationService notificationService;
     @Mock
     FriendRequestRepository friendRequestRepository;
-
+    @Mock
+    FriendshipRepository friendshipRepository;
     @InjectMocks
     SendFriendRequestService sendFriendRequestService;
 
@@ -82,7 +84,7 @@ class SendFriendRequestServiceTest {
     }
 
     @Test
-    @DisplayName("실패 - 이미 신청함")
+    @DisplayName("실패 - 이미 신청한 상태")
     void failedByAlreadyExists() {
         //given : 친구 신청 내역이 존재하는 경우(=이미 신청한 경우)
         given(friendRequestRepository.existsByFromUserIdAndToUserId(requester.getId(), requestee.getId()))
@@ -90,6 +92,23 @@ class SendFriendRequestServiceTest {
 
         given(userRepository.findByAccountId(requestee.getAccountId()))
             .willReturn(Optional.of(requestee));
+
+        //when & then : 409 Conflict 예외가 발생한다
+        assertFailedValidation(requester.getId(), requestee.getAccountId(), HttpStatus.CONFLICT);
+    }
+
+    @Test
+    @DisplayName("실패 - 이미 친구인 상태")
+    void test() {
+        //given: 이미 친구인 경우
+        given(friendshipRepository.existsByUserIdAndFriendId(requester.getId(), requestee.getId()))
+            .willReturn(true);
+
+        given(userRepository.findByAccountId(requestee.getAccountId()))
+            .willReturn(Optional.of(requestee));
+
+        given(friendRequestRepository.existsByFromUserIdAndToUserId(requester.getId(), requestee.getId()))
+            .willReturn(false);
 
         //when & then : 409 Conflict 예외가 발생한다
         assertFailedValidation(requester.getId(), requestee.getAccountId(), HttpStatus.CONFLICT);

--- a/src/test/java/today/seasoning/seasoning/friendship/service/SendFriendRequestServiceTest.java
+++ b/src/test/java/today/seasoning/seasoning/friendship/service/SendFriendRequestServiceTest.java
@@ -22,7 +22,7 @@ import today.seasoning.seasoning.user.domain.UserRepository;
 
 @DisplayName("친구 신청 서비스")
 @ExtendWith(MockitoExtension.class)
-class RequestFriendshipServiceTest {
+class SendFriendRequestServiceTest {
 
     @Mock
     UserRepository userRepository;
@@ -32,7 +32,7 @@ class RequestFriendshipServiceTest {
     FriendRequestRepository friendRequestRepository;
 
     @InjectMocks
-    RequestFriendshipService requestFriendshipService;
+    SendFriendRequestService sendFriendRequestService;
 
     User requester = new User("requester", "https://test.com/requester.jpg", "requester@email.com", LoginType.KAKAO);
     User requestee = new User("requestee", "https://test.com/requestee.jpg", "requestee@email.com", LoginType.KAKAO);
@@ -54,7 +54,7 @@ class RequestFriendshipServiceTest {
             .willReturn(false);
 
         //when & then : 예외가 발생하지 않는다
-        assertDoesNotThrow(() -> requestFriendshipService.doService(requester.getId(), requestee.getAccountId()));
+        assertDoesNotThrow(() -> sendFriendRequestService.doService(requester.getId(), requestee.getAccountId()));
     }
 
     @Test
@@ -96,7 +96,7 @@ class RequestFriendshipServiceTest {
     }
 
     private void assertFailedValidation(Long requesterId, String requesteeAccountId, HttpStatus httpStatus) {
-        assertThatThrownBy(() -> requestFriendshipService.doService(requesterId, requesteeAccountId))
+        assertThatThrownBy(() -> sendFriendRequestService.doService(requesterId, requesteeAccountId))
             .isInstanceOf(CustomException.class)
             .hasFieldOrPropertyWithValue("httpStatus", httpStatus);
     }


### PR DESCRIPTION
## 📟 연결된 이슈
- close #14

## 👷 작업한 내용
- **이미 친구인 경우 친구 신청을 거부하도록 예외처리 추가**
- 해당 예외처리에 대한 단위 테스트 작성
- 가독성 개선을 위한 클래스명 변경 : RequestFriendshipService -> SendFriendRequestService
  - 직접적으로 다루는 엔티티가 FriendRequest이므로, 이를 이름에 반영
