### PR TITLE
친구 수락 시, 서로의 친구 요청 내역을 함께 삭제

### DIFF
--- a/src/main/java/today/seasoning/seasoning/friendship/service/AcceptFriendRequestService.java
+++ b/src/main/java/today/seasoning/seasoning/friendship/service/AcceptFriendRequestService.java
@@ -44,6 +44,7 @@ public class AcceptFriendRequestService {
 
         // 친구 요청 내역 삭제
         friendRequestRepository.deleteByFromUserIdAndToUserId(requester.getId(), user.getId());
+        friendRequestRepository.deleteByFromUserIdAndToUserId(user.getId(), requester.getId());
 
         // 알림 등록
         registerNotifications(user, requester);

--- a/src/test/java/today/seasoning/seasoning/friendship/service/AcceptFriendRequestServiceTest.java
+++ b/src/test/java/today/seasoning/seasoning/friendship/service/AcceptFriendRequestServiceTest.java
@@ -1,10 +1,11 @@
 package today.seasoning.seasoning.friendship.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
 
 import java.util.Optional;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,15 +49,18 @@ class AcceptFriendRequestServiceTest {
     @Test
     @DisplayName("성공")
     void success() {
-        //given : 상대방이 조회되고, 상대로부터 나에게 온 친구 신청 내역이 존재하면
+        //given : 아이디로 상대방이 조회되고, 상대방이 나에게 친구 요청한 경우
         given(userRepository.findByAccountId(requester.getAccountId()))
             .willReturn(Optional.of(requester));
 
         given(friendRequestRepository.existsByFromUserIdAndToUserId(requester.getId(), user.getId()))
             .willReturn(true);
 
-        //when & then : 예외가 발생하지 않는다
-        Assertions.assertDoesNotThrow(() -> acceptFriendRequestService.doService(user.getId(), requester.getAccountId()));
+        //when & then : 친구 수락 시, 예외가 발생하지 않으며
+        assertDoesNotThrow(() -> acceptFriendRequestService.doService(user.getId(), requester.getAccountId()));
+        // 서로의 친구 요청 내역이 삭제되어야 한다
+        verify(friendRequestRepository).deleteByFromUserIdAndToUserId(requester.getId(), user.getId());
+        verify(friendRequestRepository).deleteByFromUserIdAndToUserId(user.getId(), requester.getId());
     }
 
     @Test


### PR DESCRIPTION
## 📟 연결된 이슈
- close #17 

## 👷 작업한 내용
- 친구 수락 시, 서로의 친구 요청 내역을 함께 삭제하도록 구현
  - before : 친구 수락 시 상대방의 친구 요청 내역만 삭제하고, 자신이 상대에게 보낸 친구 요청은 삭제하지 않음
    - 불필요한 요청 내역이 남아있음
  - after : 친구 수락 시, 서로의 친구 요청 내역을 함께 삭제
