### PR TITLE
HTTP 상태 코드 중간 점검

### DIFF
--- a/src/main/java/today/seasoning/seasoning/article/service/ArticleLikeService.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/ArticleLikeService.java
@@ -51,7 +51,7 @@ public class ArticleLikeService {
 		validatePermission(userId, article);
 
 		ArticleLike articleLike = articleLikeRepository.findByArticleAndUser(articleId, userId)
-			.orElseThrow(() -> new CustomException(HttpStatus.FORBIDDEN, "좋아요를 누르지 않았습니다"));
+			.orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST, "좋아요를 누르지 않았습니다"));
 
 		articleLikeRepository.delete(articleLike);
 	}

--- a/src/main/java/today/seasoning/seasoning/article/service/RegisterArticleService.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/RegisterArticleService.java
@@ -53,7 +53,7 @@ public class RegisterArticleService {
         }
 
         if (command.getImages().size() > ARTICLE_IMAGES_LIMIT) {
-            throw new CustomException(HttpStatus.FORBIDDEN, "이미지 개수 초과");
+            throw new CustomException(HttpStatus.BAD_REQUEST, "이미지 개수 초과");
         }
     }
 

--- a/src/main/java/today/seasoning/seasoning/article/service/UpdateArticleService.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/UpdateArticleService.java
@@ -50,7 +50,7 @@ public class UpdateArticleService {
         }
 
         if (command.getImages().size() > ARTICLE_IMAGES_LIMIT) {
-            throw new CustomException(HttpStatus.FORBIDDEN, "이미지 개수 초과");
+            throw new CustomException(HttpStatus.BAD_REQUEST, "이미지 개수 초과");
         }
 
         Long authorId = article.getUser().getId();

--- a/src/main/java/today/seasoning/seasoning/common/config/JwtFilter.java
+++ b/src/main/java/today/seasoning/seasoning/common/config/JwtFilter.java
@@ -77,7 +77,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private UserPrincipal createPrincipal(String token) {
         User user = userRepository.findById(JwtUtil.getUserId(token))
-            .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
+            .orElseThrow(() -> new CustomException(HttpStatus.UNAUTHORIZED, "Invalid Token Claims"));
 
         return UserPrincipal.build(user);
     }

--- a/src/main/java/today/seasoning/seasoning/user/domain/AccountId.java
+++ b/src/main/java/today/seasoning/seasoning/user/domain/AccountId.java
@@ -24,7 +24,7 @@ public class AccountId {
         String regex = "^(?!.*\\.\\.)(?!.*\\.$)[^\\W][\\w.]{4,19}$";
 
         if (accountId == null || accountId.matches(upperCases) || !accountId.matches(regex)) {
-            throw new CustomException(HttpStatus.FORBIDDEN, "Invalid ID Format");
+            throw new CustomException(HttpStatus.BAD_REQUEST, "Invalid ID Format");
         }
     }
 

--- a/src/main/java/today/seasoning/seasoning/user/domain/Nickname.java
+++ b/src/main/java/today/seasoning/seasoning/user/domain/Nickname.java
@@ -22,7 +22,7 @@ public class Nickname {
         String regex = "^[a-zA-Z0-9가-힣]{2,10}$";
 
         if (nickname == null || !Pattern.matches(regex, nickname)) {
-            throw new CustomException(HttpStatus.FORBIDDEN, "Invalid Nickname");
+            throw new CustomException(HttpStatus.BAD_REQUEST, "Invalid Nickname");
         }
     }
 

--- a/src/test/java/today/seasoning/seasoning/user/domain/AccountIdTest.java
+++ b/src/test/java/today/seasoning/seasoning/user/domain/AccountIdTest.java
@@ -81,6 +81,6 @@ class AccountIdTest {
     private void assertFailedValidation(String invalidAccountId) {
         assertThatThrownBy(() -> new AccountId(invalidAccountId))
             .isInstanceOf(CustomException.class)
-            .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.FORBIDDEN);
+            .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/test/java/today/seasoning/seasoning/user/domain/NicknameTest.java
+++ b/src/test/java/today/seasoning/seasoning/user/domain/NicknameTest.java
@@ -54,6 +54,6 @@ class NicknameTest {
     private void assertFailedValidation(String invalidNickname) {
         assertThatThrownBy(() -> new Nickname(invalidNickname))
             .isInstanceOf(CustomException.class)
-            .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.FORBIDDEN);
+            .hasFieldOrPropertyWithValue("httpStatus", HttpStatus.BAD_REQUEST);
     }
 }


### PR DESCRIPTION
## 📟 연결된 이슈
- close #24 

## 👷 작업한 내용
- 서버에서 클라이언트로 응답하는 HTTP 상태 코드를 점검 및 개선

## 🚨 변경 사항
- Not Found -> Unauthorized
  - JWT sub claim 오류 
- Forbidden -> Bad Request
  - 기록장 이미지 개수 초과
  - 기록장 좋아요 안눌렀는데 취소 누르는 경우
  - 아이디, 닉네임 형식 안맞는 경우
