### PR TITLE
회원탈퇴 기능 구현

### DIFF
--- a/src/main/java/today/seasoning/seasoning/article/domain/Article.java
+++ b/src/main/java/today/seasoning/seasoning/article/domain/Article.java
@@ -3,6 +3,8 @@ package today.seasoning.seasoning.article.domain;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Check;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import today.seasoning.seasoning.common.BaseTimeEntity;
 import today.seasoning.seasoning.common.util.TsidUtil;
 import today.seasoning.seasoning.user.domain.User;
@@ -19,8 +21,9 @@ public class Article extends BaseTimeEntity {
     @Column(name = "article_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     private boolean published;

--- a/src/main/java/today/seasoning/seasoning/article/domain/ArticleImageRepository.java
+++ b/src/main/java/today/seasoning/seasoning/article/domain/ArticleImageRepository.java
@@ -1,7 +1,12 @@
 package today.seasoning.seasoning.article.domain;
 
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ArticleImageRepository extends JpaRepository<ArticleImage, Long> {
 
+    @Query("SELECT i.filename FROM ArticleImage i WHERE i.article.user.id = :userId")
+    Set<String> findImageFileNamesByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/today/seasoning/seasoning/friendship/domain/FriendRequest.java
+++ b/src/main/java/today/seasoning/seasoning/friendship/domain/FriendRequest.java
@@ -7,6 +7,8 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import today.seasoning.seasoning.common.BaseTimeEntity;
 import today.seasoning.seasoning.common.util.TsidUtil;
 import today.seasoning.seasoning.user.domain.User;
@@ -21,10 +23,12 @@ public class FriendRequest extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "from_user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User fromUser;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "to_user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User toUser;
 
     public FriendRequest(User fromUser, User toUser) {

--- a/src/main/java/today/seasoning/seasoning/friendship/domain/Friendship.java
+++ b/src/main/java/today/seasoning/seasoning/friendship/domain/Friendship.java
@@ -7,6 +7,8 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import today.seasoning.seasoning.common.BaseTimeEntity;
 import today.seasoning.seasoning.common.util.TsidUtil;
 import today.seasoning.seasoning.user.domain.User;
@@ -19,12 +21,14 @@ public class Friendship extends BaseTimeEntity {
 	@Id
 	private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
+	@ManyToOne(fetch = FetchType.LAZY)
+	@OnDelete(action = OnDeleteAction.CASCADE)
 	private User user;
 
-	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "friend_id")
+	@ManyToOne(fetch = FetchType.LAZY)
+	@OnDelete(action = OnDeleteAction.CASCADE)
 	private User friend;
 
 	public Friendship(User user, User friend) {

--- a/src/main/java/today/seasoning/seasoning/notification/domain/Notification.java
+++ b/src/main/java/today/seasoning/seasoning/notification/domain/Notification.java
@@ -10,6 +10,8 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import today.seasoning.seasoning.common.BaseTimeEntity;
 import today.seasoning.seasoning.common.util.TsidUtil;
 import today.seasoning.seasoning.user.domain.User;
@@ -24,6 +26,7 @@ public class Notification extends BaseTimeEntity {
 
 	@JoinColumn(name = "user_id")
 	@ManyToOne(fetch = FetchType.LAZY)
+	@OnDelete(action = OnDeleteAction.CASCADE)
 	private User user;
 
 	@Enumerated(EnumType.STRING)
@@ -34,8 +37,7 @@ public class Notification extends BaseTimeEntity {
 	@Column(name = "is_read")
 	private boolean isRead;
 
-	private Notification(Long id, User user, NotificationType type, String message,
-		boolean isRead) {
+	private Notification(Long id, User user, NotificationType type, String message, boolean isRead) {
 		this.id = id;
 		this.user = user;
 		this.type = type;
@@ -43,11 +45,7 @@ public class Notification extends BaseTimeEntity {
 	}
 
 	public static Notification create(NotificationType type, User user, String message) {
-		return new Notification(TsidUtil.createLong(),
-			user,
-			type,
-			message,
-			false);
+		return new Notification(TsidUtil.createLong(), user, type, message, false);
 	}
 
 	public void markAsRead() {

--- a/src/main/java/today/seasoning/seasoning/user/controller/UserController.java
+++ b/src/main/java/today/seasoning/seasoning/user/controller/UserController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +18,7 @@ import today.seasoning.seasoning.user.domain.AccountId;
 import today.seasoning.seasoning.user.dto.UpdateUserProfileCommand;
 import today.seasoning.seasoning.user.dto.UpdateUserProfileDto;
 import today.seasoning.seasoning.user.dto.UserProfileDto;
+import today.seasoning.seasoning.user.service.DeleteUserService;
 import today.seasoning.seasoning.user.service.FindUserProfileService;
 import today.seasoning.seasoning.user.service.UpdateUserProfileService;
 import today.seasoning.seasoning.user.service.VerifyAccountIdService;
@@ -29,6 +31,7 @@ public class UserController {
     private final UpdateUserProfileService updateUserProfile;
     private final FindUserProfileService findUserProfileService;
     private final VerifyAccountIdService verifyAccountIdService;
+    private final DeleteUserService deleteUserService;
 
     // 프로필 조회
     @GetMapping("/profile")
@@ -61,5 +64,11 @@ public class UserController {
             return ResponseEntity.ok().build();
         }
         return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> unregister(@AuthenticationPrincipal UserPrincipal principal) {
+        deleteUserService.doService(principal.getId());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/today/seasoning/seasoning/user/service/DeleteUserService.java
+++ b/src/main/java/today/seasoning/seasoning/user/service/DeleteUserService.java
@@ -1,0 +1,38 @@
+package today.seasoning.seasoning.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import today.seasoning.seasoning.article.domain.ArticleImageRepository;
+import today.seasoning.seasoning.common.aws.S3Service;
+import today.seasoning.seasoning.common.exception.CustomException;
+import today.seasoning.seasoning.user.domain.User;
+import today.seasoning.seasoning.user.domain.UserRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DeleteUserService {
+
+    private final S3Service s3Service;
+    private final UserRepository userRepository;
+    private final ArticleImageRepository articleImageRepository;
+
+    public void doService(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "User Not Found"));
+
+        // Amazon S3 파일 삭제 : 프로필 사진
+        if(StringUtils.hasLength(user.getProfileImageFilename())) {
+            s3Service.deleteFile(user.getProfileImageFilename());
+        }
+
+        // Amazon S3 파일 삭제 : 기록장 사진
+        articleImageRepository.findImageFileNamesByUserId(userId)
+                .forEach(s3Service::deleteFile);
+
+        userRepository.delete(user);
+    }
+}


### PR DESCRIPTION
## 📟 연결된 이슈
- close #37 

## 👷 작업한 내용
- 회원 탈퇴 기능 구현
  - 회원 탈퇴 시, 회원 데이터가 함께 삭제되도록 관련 엔티티에 'On Delete Cascade' 적용
- 회원 탈퇴 API 구현
  - Endpoint URL : DELETE /user
  - 액세스 토큰 요구

## 🚨 참고 사항
- 단방향 연관관계의 경우, @OnDelete 어노테이션을 사용하여 자식 엔티티를 함께 삭제한다
- https://stackoverflow.com/questions/7197181/jpa-unidirectional-many-to-one-and-cascading-delete
- https://chiki-cha.tistory.com/144
- https://kukekyakya.tistory.com/546