### PR TITLE
절기 조회 API 구현

### DIFF
--- a/src/main/java/today/seasoning/seasoning/solarterm/controller/SolarTermController.java
+++ b/src/main/java/today/seasoning/seasoning/solarterm/controller/SolarTermController.java
@@ -3,21 +3,31 @@ package today.seasoning.seasoning.solarterm.controller;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import today.seasoning.seasoning.solarterm.dto.FindSolarTermInfoResponse;
 import today.seasoning.seasoning.solarterm.service.FindAndRegisterSolarTermsService;
+import today.seasoning.seasoning.solarterm.service.SolarTermService;
 
 @RestController
 @RequiredArgsConstructor
 public class SolarTermController {
 
+    private final SolarTermService solarTermService;
     private final FindAndRegisterSolarTermsService findAndRegisterSolarTermsService;
 
     @PostMapping("/admin/solar-term")
     public ResponseEntity<Void> registerSolarTermsOfYear(@Valid @RequestBody YearDto yearDto) {
         findAndRegisterSolarTermsService.findAndRegisterSolarTermsOf(yearDto.getYear());
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/solarTerm")
+    public ResponseEntity<FindSolarTermInfoResponse> findSolarTermInfo() {
+        FindSolarTermInfoResponse solarTermInfoResponse = solarTermService.findSolarTermInfo();
+        return ResponseEntity.ok(solarTermInfoResponse);
     }
 
 }

--- a/src/main/java/today/seasoning/seasoning/solarterm/domain/SolarTerm.java
+++ b/src/main/java/today/seasoning/seasoning/solarterm/domain/SolarTerm.java
@@ -1,6 +1,7 @@
 package today.seasoning.seasoning.solarterm.domain;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import lombok.Getter;
@@ -24,5 +25,9 @@ public class SolarTerm extends BaseTimeEntity {
         this.id = TsidUtil.createLong();
         this.sequence = sequence;
         this.date = date;
+    }
+
+    public int getDaysDiff(LocalDate date) {
+        return (int) Math.abs(ChronoUnit.DAYS.between(this.date, date));
     }
 }

--- a/src/main/java/today/seasoning/seasoning/solarterm/domain/SolarTerm.java
+++ b/src/main/java/today/seasoning/seasoning/solarterm/domain/SolarTerm.java
@@ -18,25 +18,11 @@ public class SolarTerm extends BaseTimeEntity {
 
     private int sequence;
 
-    private int year;
-
-    private int month;
-
-    private int day;
-
-    public SolarTerm(int sequence, int year, int month, int day) {
-        this.id = TsidUtil.createLong();
-        this.sequence = sequence;
-        this.year = year;
-        this.month = month;
-        this.day = day;
-    }
+    private LocalDate date;
 
     public SolarTerm(int sequence, LocalDate date) {
         this.id = TsidUtil.createLong();
         this.sequence = sequence;
-        this.year = date.getYear();
-        this.month = date.getMonthValue();
-        this.day = date.getDayOfMonth();
+        this.date = date;
     }
 }

--- a/src/main/java/today/seasoning/seasoning/solarterm/domain/SolarTermRepository.java
+++ b/src/main/java/today/seasoning/seasoning/solarterm/domain/SolarTermRepository.java
@@ -2,12 +2,10 @@ package today.seasoning.seasoning.solarterm.domain;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SolarTermRepository extends JpaRepository<SolarTerm, Long> {
 
-    @Query
-    List<SolarTerm> findByYearAndMonth(int year, int month);
+    List<SolarTerm> findAllByOrderByDateAsc();
 }

--- a/src/main/java/today/seasoning/seasoning/solarterm/dto/FindSolarTermInfoResponse.java
+++ b/src/main/java/today/seasoning/seasoning/solarterm/dto/FindSolarTermInfoResponse.java
@@ -1,0 +1,27 @@
+package today.seasoning.seasoning.solarterm.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import today.seasoning.seasoning.solarterm.domain.SolarTerm;
+
+@Getter
+@AllArgsConstructor
+@JsonInclude(Include.NON_NULL)
+public class FindSolarTermInfoResponse {
+
+    private final boolean recordable;
+    private final SolarTermDto currentTerm;
+    private final SolarTermDto nextTerm;
+    private final SolarTermDto recordTerm;
+
+    public static FindSolarTermInfoResponse build(SolarTerm currentSolarTerm, SolarTerm nextSolarTerm, SolarTerm recordSolarTerm) {
+        boolean recordable = recordSolarTerm != null;
+        SolarTermDto currentTerm = SolarTermDto.build(currentSolarTerm);
+        SolarTermDto nextTerm = SolarTermDto.build(nextSolarTerm);
+        SolarTermDto recordTerm = recordable ? SolarTermDto.build(recordSolarTerm) : null;
+
+        return new FindSolarTermInfoResponse(recordable, currentTerm, nextTerm, recordTerm);
+    }
+}

--- a/src/main/java/today/seasoning/seasoning/solarterm/dto/FindSolarTermInfoResponse.java
+++ b/src/main/java/today/seasoning/seasoning/solarterm/dto/FindSolarTermInfoResponse.java
@@ -16,11 +16,17 @@ public class FindSolarTermInfoResponse {
     private final SolarTermDto nextTerm;
     private final SolarTermDto recordTerm;
 
-    public static FindSolarTermInfoResponse build(SolarTerm currentSolarTerm, SolarTerm nextSolarTerm, SolarTerm recordSolarTerm) {
+    public static FindSolarTermInfoResponse build(SolarTerm currentSolarTerm, SolarTerm nextSolarTerm, SolarTerm recordSolarTerm, int recordPeriod) {
         boolean recordable = recordSolarTerm != null;
         SolarTermDto currentTerm = SolarTermDto.build(currentSolarTerm);
         SolarTermDto nextTerm = SolarTermDto.build(nextSolarTerm);
-        SolarTermDto recordTerm = recordable ? SolarTermDto.build(recordSolarTerm) : null;
+
+        SolarTermDto recordTerm = null;
+        if(recordable) {
+            recordTerm = new SolarTermDto(
+                recordSolarTerm.getSequence(),
+                recordSolarTerm.getDate().plusDays(recordPeriod));
+        }
 
         return new FindSolarTermInfoResponse(recordable, currentTerm, nextTerm, recordTerm);
     }

--- a/src/main/java/today/seasoning/seasoning/solarterm/dto/SolarTermDto.java
+++ b/src/main/java/today/seasoning/seasoning/solarterm/dto/SolarTermDto.java
@@ -10,7 +10,7 @@ import today.seasoning.seasoning.solarterm.domain.SolarTerm;
 public class SolarTermDto {
 
     private final int sequence;
-    private final LocalDate localDate;
+    private final LocalDate date;
 
     public static SolarTermDto build(SolarTerm solarTerm) {
         return new SolarTermDto(solarTerm.getSequence(), solarTerm.getDate());

--- a/src/main/java/today/seasoning/seasoning/solarterm/dto/SolarTermDto.java
+++ b/src/main/java/today/seasoning/seasoning/solarterm/dto/SolarTermDto.java
@@ -1,0 +1,18 @@
+package today.seasoning.seasoning.solarterm.dto;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import today.seasoning.seasoning.solarterm.domain.SolarTerm;
+
+@Getter
+@RequiredArgsConstructor
+public class SolarTermDto {
+
+    private final int sequence;
+    private final LocalDate localDate;
+
+    public static SolarTermDto build(SolarTerm solarTerm) {
+        return new SolarTermDto(solarTerm.getSequence(), solarTerm.getDate());
+    }
+}

--- a/src/main/java/today/seasoning/seasoning/solarterm/service/SolarTermService.java
+++ b/src/main/java/today/seasoning/seasoning/solarterm/service/SolarTermService.java
@@ -83,6 +83,7 @@ public class SolarTermService {
     }
 
     public FindSolarTermInfoResponse findSolarTermInfo() {
-        return FindSolarTermInfoResponse.build(currentSolarTerm, nextSolarTerm, recordSolarTerm.orElse(null));
+        return FindSolarTermInfoResponse.build(currentSolarTerm, nextSolarTerm, recordSolarTerm.orElse(null),
+            ARTICLE_REGISTRATION_PERIOD);
     }
 }

--- a/src/main/java/today/seasoning/seasoning/solarterm/service/SolarTermService.java
+++ b/src/main/java/today/seasoning/seasoning/solarterm/service/SolarTermService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import today.seasoning.seasoning.notification.service.NotificationService;
 import today.seasoning.seasoning.solarterm.domain.SolarTerm;
 import today.seasoning.seasoning.solarterm.domain.SolarTermRepository;
+import today.seasoning.seasoning.solarterm.dto.FindSolarTermInfoResponse;
 
 @Slf4j
 @Service
@@ -79,5 +80,9 @@ public class SolarTermService {
 
     public Optional<SolarTerm> findRecordSolarTerm() {
         return recordSolarTerm;
+    }
+
+    public FindSolarTermInfoResponse findSolarTermInfo() {
+        return FindSolarTermInfoResponse.build(currentSolarTerm, nextSolarTerm, recordSolarTerm.orElse(null));
     }
 }


### PR DESCRIPTION
## 📟 연결된 이슈
- close #36 

## 👷 작업한 내용
- 절기 조회 API 구현
- SolarTerm 엔티티 속성 변경
  - 계산 편의를 위해 day, month, year를 LocalDate로 통합

## 🚨 참고 사항
### 응답

```jsx
{
	'recordable' : boolean,
	'currentTerm' : {
		'sequence': int,
		'date': datetime
	},
	'nextTerm' : {
		'sequence': int,
		'date': datetime
	},
	'recordTerm' : {
		'sequence': int
		'date': datetime
	}
}
```

- recordable : 기록장 열림 여부
- currentTerm : 시간상 현재 절기 / nextTerm : 시간상 다음 절기
  - sequence : 절기 순번 (1~24)
  - date : 절기 날짜
- recordTerm : 기록장 작성 가능한 절기 (recordable이 false면 미포함)
  - sequence : 절기 순번 (1~24)
  - date : 기록 가능한 마지막 날짜
    - 절기가 1월 22이고 기록 가능한 기간이 앞뒤로 2일이면, 1월 24일 반환

## 📸 스크린샷
<img width="496" alt="image" src="https://github.com/Seasoning-Today/backend/assets/107951175/267aa608-a429-44d2-a1b4-7d5dd903a541">
