### PR TITLE
회원 조회 예외처리 중복 제거

### DIFF
--- a/src/main/java/today/seasoning/seasoning/article/service/ArticleLikeService.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/ArticleLikeService.java
@@ -29,7 +29,7 @@ public class ArticleLikeService {
 	private final NotificationService notificationService;
 
 	public void doLike(Long userId, Long articleId) {
-		User user = userRepository.findById(userId).get();
+		User user = userRepository.findByIdOrElseThrow(userId);
 
 		Article article = findArticleOrThrow(articleId);
 

--- a/src/main/java/today/seasoning/seasoning/article/service/RegisterArticleService.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/RegisterArticleService.java
@@ -46,7 +46,7 @@ public class RegisterArticleService {
     }
 
     private Article createArticle(RegisterArticleCommand command) {
-        User user = userRepository.findById(command.getUserId()).get();
+        User user = userRepository.findByIdOrElseThrow(command.getUserId());
 
         SolarTerm solarTerm = solarTermService.findRecordSolarTerm()
             .orElseThrow(() -> new CustomException(HttpStatus.FORBIDDEN, "등록 기간이 아닙니다."));

--- a/src/main/java/today/seasoning/seasoning/friendship/service/AcceptFriendRequestService.java
+++ b/src/main/java/today/seasoning/seasoning/friendship/service/AcceptFriendRequestService.java
@@ -28,11 +28,8 @@ public class AcceptFriendRequestService {
 
     @Transactional
     public void doService(Long userId, Long requestUserId) {
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST, "회원 조회 실패"));
-
-        User requester = userRepository.findById(requestUserId)
-            .orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST, "상대방 조회 실패"));
+        User user = userRepository.findByIdOrElseThrow(userId);
+        User requester = userRepository.findByIdOrElseThrow(requestUserId);
 
         if (!friendRequestRepository.existsByFromUserIdAndToUserId(requester.getId(), user.getId())) {
             throw new CustomException(HttpStatus.BAD_REQUEST, "신청 내역 없음");

--- a/src/main/java/today/seasoning/seasoning/friendship/service/CancelFriendRequestService.java
+++ b/src/main/java/today/seasoning/seasoning/friendship/service/CancelFriendRequestService.java
@@ -18,8 +18,7 @@ public class CancelFriendRequestService {
     private final FriendRequestRepository friendRequestRepository;
 
     public void doService(Long userId, Long requesteeUserId) {
-        User requestee = userRepository.findById(requesteeUserId)
-            .orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST, "상대방 조회 실패"));
+        User requestee = userRepository.findByIdOrElseThrow(requesteeUserId);
 
         if (!friendRequestRepository.existsByFromUserIdAndToUserId(userId, requestee.getId())) {
             throw new CustomException(HttpStatus.BAD_REQUEST, "신청 내역 없음");

--- a/src/main/java/today/seasoning/seasoning/friendship/service/DeclineFriendRequestService.java
+++ b/src/main/java/today/seasoning/seasoning/friendship/service/DeclineFriendRequestService.java
@@ -19,8 +19,7 @@ public class DeclineFriendRequestService {
     private final FriendRequestRepository friendRequestRepository;
 
     public void doService(Long userId, Long requesterUserId) {
-        User requester = userRepository.findById(requesterUserId)
-            .orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST, "상대방 조회 실패"));
+        User requester = userRepository.findByIdOrElseThrow(requesterUserId);
 
         if (!friendRequestRepository.existsByFromUserIdAndToUserId(requester.getId(), userId)) {
             throw new CustomException(HttpStatus.BAD_REQUEST, "신청 내역 없음");

--- a/src/main/java/today/seasoning/seasoning/friendship/service/SendFriendRequestService.java
+++ b/src/main/java/today/seasoning/seasoning/friendship/service/SendFriendRequestService.java
@@ -26,10 +26,8 @@ public class SendFriendRequestService {
 	private final FriendRequestRepository friendRequestRepository;
 
 	public void doService(Long fromUserId, Long toUserId) {
-		User fromUser = userRepository.findById(fromUserId).get();
-
-		User toUser = userRepository.findById(toUserId)
-			.orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST, "상대방 조회 실패"));
+		User fromUser = userRepository.findByIdOrElseThrow(fromUserId);
+		User toUser = userRepository.findByIdOrElseThrow(toUserId);
 
 		checkException(fromUser, toUser);
 

--- a/src/main/java/today/seasoning/seasoning/friendship/service/UnfriendService.java
+++ b/src/main/java/today/seasoning/seasoning/friendship/service/UnfriendService.java
@@ -19,9 +19,7 @@ public class UnfriendService {
     private final FriendshipRepository friendshipRepository;
 
     public void doService(Long userId, Long friendUserId) {
-        User friend = userRepository.findById(friendUserId)
-            .orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST, "회원 조회 실패"));
-
+        User friend = userRepository.findByIdOrElseThrow(friendUserId);
         deleteFriendship(userId, friend.getId());
         deleteFriendship(friend.getId(), userId);
     }

--- a/src/main/java/today/seasoning/seasoning/notification/service/NotificationService.java
+++ b/src/main/java/today/seasoning/seasoning/notification/service/NotificationService.java
@@ -4,10 +4,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import today.seasoning.seasoning.common.exception.CustomException;
 import today.seasoning.seasoning.notification.domain.Notification;
 import today.seasoning.seasoning.notification.domain.NotificationRepository;
 import today.seasoning.seasoning.notification.domain.NotificationType;
@@ -26,7 +24,7 @@ public class NotificationService {
 	private final NotificationRepository notificationRepository;
 
 	public void registerNotification(Long receiveUserId, NotificationType type, String message) {
-		User user = findUserOrThrow(receiveUserId);
+		User user = userRepository.findByIdOrElseThrow(receiveUserId);
 
 		Notification notification = Notification.create(type, user, message);
 		notificationRepository.save(notification);
@@ -57,11 +55,6 @@ public class NotificationService {
 			.forEach(user -> registerNotification(user.getId(),
 				NotificationType.ARTICLE_OPEN,
 				String.valueOf(term)));
-	}
-
-	private User findUserOrThrow(Long userId) {
-		return userRepository.findById(userId)
-			.orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "회원 조회 실패"));
 	}
 
 	private void markNotificationsAsRead(List<Notification> sentNotificationList) {

--- a/src/main/java/today/seasoning/seasoning/user/domain/CustomUserRepository.java
+++ b/src/main/java/today/seasoning/seasoning/user/domain/CustomUserRepository.java
@@ -1,0 +1,9 @@
+package today.seasoning.seasoning.user.domain;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CustomUserRepository {
+
+    User findByIdOrElseThrow(Long id);
+}

--- a/src/main/java/today/seasoning/seasoning/user/domain/CustomUserRepositoryImpl.java
+++ b/src/main/java/today/seasoning/seasoning/user/domain/CustomUserRepositoryImpl.java
@@ -1,0 +1,29 @@
+package today.seasoning.seasoning.user.domain;
+
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import today.seasoning.seasoning.common.exception.CustomException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomUserRepositoryImpl implements CustomUserRepository{
+
+    private final EntityManager entityManager;
+
+    @Override
+    public User findByIdOrElseThrow(Long id) {
+        TypedQuery<User> query = entityManager.createQuery("SELECT u FROM User u WHERE u.id = :id", User.class);
+        query.setParameter("id", id);
+
+        List<User> resultList = query.getResultList();
+        if (resultList.isEmpty()) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "User Not Found");
+        }
+
+        return resultList.get(0);
+    }
+}

--- a/src/main/java/today/seasoning/seasoning/user/domain/UserRepository.java
+++ b/src/main/java/today/seasoning/seasoning/user/domain/UserRepository.java
@@ -4,9 +4,11 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 import today.seasoning.seasoning.common.enums.LoginType;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+@Repository
+public interface UserRepository extends JpaRepository<User, Long>, CustomUserRepository {
 
 	@Query("SELECT u FROM User u WHERE u.email = :email AND u.loginType = :loginType")
 	Optional<User> find(@Param("email") String email, @Param("loginType") LoginType loginType);

--- a/src/main/java/today/seasoning/seasoning/user/service/DeleteUserService.java
+++ b/src/main/java/today/seasoning/seasoning/user/service/DeleteUserService.java
@@ -1,13 +1,11 @@
 package today.seasoning.seasoning.user.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import today.seasoning.seasoning.article.domain.ArticleImageRepository;
 import today.seasoning.seasoning.common.aws.S3Service;
-import today.seasoning.seasoning.common.exception.CustomException;
 import today.seasoning.seasoning.user.domain.User;
 import today.seasoning.seasoning.user.domain.UserRepository;
 
@@ -21,8 +19,7 @@ public class DeleteUserService {
     private final ArticleImageRepository articleImageRepository;
 
     public void doService(Long userId) {
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "User Not Found"));
+        User user = userRepository.findByIdOrElseThrow(userId);
 
         // Amazon S3 파일 삭제 : 프로필 사진
         if(StringUtils.hasLength(user.getProfileImageFilename())) {

--- a/src/main/java/today/seasoning/seasoning/user/service/FindUserProfileService.java
+++ b/src/main/java/today/seasoning/seasoning/user/service/FindUserProfileService.java
@@ -16,7 +16,7 @@ public class FindUserProfileService {
 	// 프로필 조회
 	@Transactional(readOnly = true)
 	public UserProfileDto findUserProfile(Long userId) {
-		User user = userRepository.findById(userId).get();
+		User user = userRepository.findByIdOrElseThrow(userId);
 		return UserProfileDto.build(user);
 	}
 }

--- a/src/main/java/today/seasoning/seasoning/user/service/UpdateUserProfileService.java
+++ b/src/main/java/today/seasoning/seasoning/user/service/UpdateUserProfileService.java
@@ -23,7 +23,7 @@ public class UpdateUserProfileService {
 
     @Transactional
     public void doUpdate(UpdateUserProfileCommand command) {
-        User user = userRepository.findById(command.getUserId()).get();
+        User user = userRepository.findByIdOrElseThrow(command.getUserId());
         String oldProfileFilename = user.getProfileImageFilename();
 
         verifyAccountId(command, user.getAccountId());

--- a/src/test/java/today/seasoning/seasoning/friendship/service/AcceptFriendRequestServiceTest.java
+++ b/src/test/java/today/seasoning/seasoning/friendship/service/AcceptFriendRequestServiceTest.java
@@ -42,16 +42,16 @@ class AcceptFriendRequestServiceTest {
 
     @BeforeEach
     void init() {
-        given(userRepository.findById(user.getId()))
-            .willReturn(Optional.of(user));
+        given(userRepository.findByIdOrElseThrow(user.getId()))
+            .willReturn(user);
     }
 
     @Test
     @DisplayName("성공")
     void success() {
         //given : 아이디로 상대방이 조회되고, 상대방이 나에게 친구 요청한 경우
-        given(userRepository.findById(requester.getId()))
-            .willReturn(Optional.of(requester));
+        given(userRepository.findByIdOrElseThrow(requester.getId()))
+            .willReturn(requester);
 
         given(friendRequestRepository.existsByFromUserIdAndToUserId(requester.getId(), user.getId()))
             .willReturn(true);
@@ -67,8 +67,8 @@ class AcceptFriendRequestServiceTest {
     @DisplayName("실패 - 상대방 조회 불가")
     void failedByRequesterNotFound() {
         //given : 아이디에 해당하는 상대방이 존재하지 않으면
-        given(userRepository.findById(requester.getId()))
-            .willReturn(Optional.empty());
+        given(userRepository.findByIdOrElseThrow(requester.getId()))
+            .willThrow(new CustomException(HttpStatus.BAD_REQUEST, "User Not Found"));
 
         //when & then : Bad Request 예외가 발생한다
         assertFailedValidation(user.getId(), requester.getId(), HttpStatus.BAD_REQUEST);
@@ -81,8 +81,8 @@ class AcceptFriendRequestServiceTest {
         given(friendRequestRepository.existsByFromUserIdAndToUserId(requester.getId(), user.getId()))
             .willReturn(false);
 
-        given(userRepository.findById(requester.getId()))
-            .willReturn(Optional.of(requester));
+        given(userRepository.findByIdOrElseThrow(requester.getId()))
+            .willReturn(requester);
 
         //when & then : Bad Request 예외가 발생한다
         assertFailedValidation(user.getId(), requester.getId(), HttpStatus.BAD_REQUEST);

--- a/src/test/java/today/seasoning/seasoning/friendship/service/AcceptFriendRequestServiceTest.java
+++ b/src/test/java/today/seasoning/seasoning/friendship/service/AcceptFriendRequestServiceTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.verify;
 
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/today/seasoning/seasoning/friendship/service/CancelFriendRequestServiceTest.java
+++ b/src/test/java/today/seasoning/seasoning/friendship/service/CancelFriendRequestServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.BDDMockito.given;
 
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,8 +35,8 @@ class CancelFriendRequestServiceTest {
     @DisplayName("성공")
     void success() {
         //given : 상대방이 존재하고, 내가 상대방에게 친구 신청한 내역이 있으면
-        given(userRepository.findById(requestee.getId()))
-            .willReturn(Optional.of(requestee));
+        given(userRepository.findByIdOrElseThrow(requestee.getId()))
+            .willReturn(requestee);
 
         given(friendRequestRepository.existsByFromUserIdAndToUserId(user.getId(), requestee.getId()))
             .willReturn(true);
@@ -50,8 +49,8 @@ class CancelFriendRequestServiceTest {
     @DisplayName("실패 - 상대방 조회 불가")
     void failedByRequesterNotFound() {
         //given : 아이디에 해당하는 상대방이 존재하지 않으면
-        given(userRepository.findById(requestee.getId()))
-            .willReturn(Optional.empty());
+        given(userRepository.findByIdOrElseThrow(requestee.getId()))
+            .willThrow(new CustomException(HttpStatus.BAD_REQUEST, "User Not Found"));
 
         //when & then : Bad Request 예외가 발생한다
         assertFailedValidation(user.getId(), requestee.getId(), HttpStatus.BAD_REQUEST);
@@ -64,8 +63,8 @@ class CancelFriendRequestServiceTest {
         given(friendRequestRepository.existsByFromUserIdAndToUserId(user.getId(), requestee.getId()))
             .willReturn(false);
 
-        given(userRepository.findById(requestee.getId()))
-            .willReturn(Optional.of(requestee));
+        given(userRepository.findByIdOrElseThrow(requestee.getId()))
+            .willReturn(requestee);
 
         //when & then : Bad Request 예외가 발생한다
         assertFailedValidation(user.getId(), requestee.getId(), HttpStatus.BAD_REQUEST);

--- a/src/test/java/today/seasoning/seasoning/friendship/service/DeclineFriendRequestServiceTest.java
+++ b/src/test/java/today/seasoning/seasoning/friendship/service/DeclineFriendRequestServiceTest.java
@@ -1,10 +1,9 @@
 package today.seasoning.seasoning.friendship.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.BDDMockito.given;
 
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,8 +35,8 @@ class DeclineFriendRequestServiceTest {
     @DisplayName("성공")
     void success() {
         //given : 상대방이 조회되고, 상대로부터 나에게 온 친구 신청 내역이 존재하면
-        given(userRepository.findById(requester.getId()))
-            .willReturn(Optional.of(requester));
+        given(userRepository.findByIdOrElseThrow(requester.getId()))
+            .willReturn(requester);
 
         given(friendRequestRepository.existsByFromUserIdAndToUserId(requester.getId(), user.getId()))
             .willReturn(true);
@@ -50,8 +49,8 @@ class DeclineFriendRequestServiceTest {
     @DisplayName("실패 - 상대방 조회 불가")
     void failedByRequesterNotFound() {
         //given : 아이디에 해당하는 상대방이 존재하지 않으면
-        given(userRepository.findById(requester.getId()))
-            .willReturn(Optional.empty());
+        given(userRepository.findByIdOrElseThrow(requester.getId()))
+            .willThrow(new CustomException(HttpStatus.BAD_REQUEST, "User Not Found"));
 
         //when & then : Bad Request 예외가 발생한다
         assertFailedValidation(user.getId(), requester.getId(), HttpStatus.BAD_REQUEST);
@@ -64,8 +63,8 @@ class DeclineFriendRequestServiceTest {
         given(friendRequestRepository.existsByFromUserIdAndToUserId(requester.getId(), user.getId()))
             .willReturn(false);
 
-        given(userRepository.findById(requester.getId()))
-            .willReturn(Optional.of(requester));
+        given(userRepository.findByIdOrElseThrow(requester.getId()))
+            .willReturn(requester);
 
         //when & then : Bad Request 예외가 발생한다
         assertFailedValidation(user.getId(), requester.getId(), HttpStatus.BAD_REQUEST);

--- a/src/test/java/today/seasoning/seasoning/friendship/service/SendFriendRequestServiceTest.java
+++ b/src/test/java/today/seasoning/seasoning/friendship/service/SendFriendRequestServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.BDDMockito.given;
 
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/today/seasoning/seasoning/friendship/service/SendFriendRequestServiceTest.java
+++ b/src/test/java/today/seasoning/seasoning/friendship/service/SendFriendRequestServiceTest.java
@@ -41,16 +41,16 @@ class SendFriendRequestServiceTest {
 
     @BeforeEach
     void initUserRepository() {
-        given(userRepository.findById(requester.getId()))
-            .willReturn(Optional.of(requester));
+        given(userRepository.findByIdOrElseThrow(requester.getId()))
+            .willReturn(requester);
     }
 
     @Test
     @DisplayName("성공")
     void success() {
         //given : 상대방이 존재하고, 친구 신청 내역이 없으면
-        given(userRepository.findById(requestee.getId()))
-            .willReturn(Optional.of(requestee));
+        given(userRepository.findByIdOrElseThrow(requestee.getId()))
+            .willReturn(requestee);
 
         given(friendRequestRepository.existsByFromUserIdAndToUserId(requester.getId(), requestee.getId()))
             .willReturn(false);
@@ -63,8 +63,8 @@ class SendFriendRequestServiceTest {
     @DisplayName("실패 - 상대방 조회 실패")
     void failedByRequesteeNotFound() {
         //given : 아이디에 해당하는 회원이 없는 경우
-        given(userRepository.findById(requestee.getId()))
-            .willReturn(Optional.empty());
+        given(userRepository.findByIdOrElseThrow(requestee.getId()))
+            .willThrow(new CustomException(HttpStatus.BAD_REQUEST, "User Not Found"));
 
         //when & then : Bad Request 예외가 발생한다
         assertFailedValidation(requester.getId(), requestee.getId(), HttpStatus.BAD_REQUEST);
@@ -76,8 +76,8 @@ class SendFriendRequestServiceTest {
         //given : 자신의 아이디로 친구 신청한 경우
         Long userId = requester.getId();
 
-        given(userRepository.findById(userId))
-            .willReturn(Optional.of(requester));
+        given(userRepository.findByIdOrElseThrow(userId))
+            .willReturn(requester);
 
         //when & then : Bad Request 예외가 발생한다
         assertFailedValidation(requester.getId(), userId, HttpStatus.BAD_REQUEST);
@@ -90,8 +90,8 @@ class SendFriendRequestServiceTest {
         given(friendRequestRepository.existsByFromUserIdAndToUserId(requester.getId(), requestee.getId()))
             .willReturn(true);
 
-        given(userRepository.findById(requestee.getId()))
-            .willReturn(Optional.of(requestee));
+        given(userRepository.findByIdOrElseThrow(requestee.getId()))
+            .willReturn(requestee);
 
         //when & then : 409 Conflict 예외가 발생한다
         assertFailedValidation(requester.getId(), requestee.getId(), HttpStatus.CONFLICT);
@@ -104,8 +104,8 @@ class SendFriendRequestServiceTest {
         given(friendshipRepository.existsByUserIdAndFriendId(requester.getId(), requestee.getId()))
             .willReturn(true);
 
-        given(userRepository.findById(requestee.getId()))
-            .willReturn(Optional.of(requestee));
+        given(userRepository.findByIdOrElseThrow(requestee.getId()))
+            .willReturn(requestee);
 
         given(friendRequestRepository.existsByFromUserIdAndToUserId(requester.getId(), requestee.getId()))
             .willReturn(false);

--- a/src/test/java/today/seasoning/seasoning/friendship/service/UnfriendServiceTest.java
+++ b/src/test/java/today/seasoning/seasoning/friendship/service/UnfriendServiceTest.java
@@ -43,8 +43,8 @@ class UnfriendServiceTest {
     @DisplayName("성공")
     void test() {
         //given : 아이디에 해당하는 사용자가 존재하고, 해당 사용자와 회원간의 친구 관계가 양방향으로 존재하는 경우
-        BDDMockito.given(userRepository.findById(friend.getId()))
-            .willReturn(Optional.of(friend));
+        BDDMockito.given(userRepository.findByIdOrElseThrow(friend.getId()))
+            .willReturn(friend);
 
         BDDMockito.given(friendshipRepository.findByUserIdAndFriendId(user.getId(), friend.getId()))
             .willReturn(Optional.of(userToFriendFriendship));
@@ -60,8 +60,8 @@ class UnfriendServiceTest {
     @DisplayName("실패 - 상대방 조회 불가")
     void failedByFriendNotFound() {
         //given : 아이디에 해당하는 사용자가 존재하지 않으면
-        given(userRepository.findById(friend.getId()))
-            .willReturn(Optional.empty());
+        given(userRepository.findByIdOrElseThrow(friend.getId()))
+            .willThrow(new CustomException(HttpStatus.BAD_REQUEST, "User Not Found"));
 
         //when & then : Bad Request 예외가 발생한다
         assertFailedValidation(user.getId(), friend.getId(), HttpStatus.BAD_REQUEST);
@@ -77,8 +77,8 @@ class UnfriendServiceTest {
         BDDMockito.given(friendshipRepository.findByUserIdAndFriendId(friend.getId(), user.getId()))
             .willReturn(Optional.of(friendToUserFriendship));
 
-        BDDMockito.given(userRepository.findById(friend.getId()))
-            .willReturn(Optional.of(friend));
+        BDDMockito.given(userRepository.findByIdOrElseThrow(friend.getId()))
+            .willReturn(friend);
 
         //when & then : Bad Request 예외가 발생한다
         assertFailedValidation(user.getId(), friend.getId(), HttpStatus.BAD_REQUEST);
@@ -94,8 +94,8 @@ class UnfriendServiceTest {
         BDDMockito.given(friendshipRepository.findByUserIdAndFriendId(user.getId(), friend.getId()))
             .willReturn(Optional.of(userToFriendFriendship));
 
-        BDDMockito.given(userRepository.findById(friend.getId()))
-            .willReturn(Optional.of(friend));
+        BDDMockito.given(userRepository.findByIdOrElseThrow(friend.getId()))
+            .willReturn(friend);
 
         //when & then : Bad Request 예외가 발생한다
         assertFailedValidation(user.getId(), friend.getId(), HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
## 👷 작업한 내용
- 회언 조회 실패 예외처리 중복 제거
  - Optional.orElseThrow() 코드가 산발적으로 중복되어 발생
  - CustomUserRepository.findByIdOrElseThrow() 메서드를 추가하여 중복코드를 제거
