### PR TITLE
기록장 중복 등록 방지

### DIFF
--- a/src/main/java/today/seasoning/seasoning/article/domain/Article.java
+++ b/src/main/java/today/seasoning/seasoning/article/domain/Article.java
@@ -15,6 +15,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor
+@Table(name = "article", uniqueConstraints = { @UniqueConstraint(columnNames = {"user_id", "created_year", "created_term"})})
 public class Article extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/today/seasoning/seasoning/article/domain/ArticleRepository.java
+++ b/src/main/java/today/seasoning/seasoning/article/domain/ArticleRepository.java
@@ -12,4 +12,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
 	@Query("SELECT a From Article a WHERE a.user.id = :userId AND a.createdTerm = :term")
 	List<Article> findByUserIdAndTerm(@Param("userId") Long userId, @Param("term") int term);
+
+	@Query("SELECT COUNT(a) > 0 FROM Article a WHERE a.user.id = :userId AND a.createdYear = :year AND a.createdTerm = :term")
+	boolean checkArticleRegistered(@Param("userId") Long userId, @Param("year") int year, @Param("term") int term);
 }

--- a/src/main/java/today/seasoning/seasoning/article/service/RegisterArticleService.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/RegisterArticleService.java
@@ -50,6 +50,10 @@ public class RegisterArticleService {
         SolarTerm solarTerm = solarTermService.findRecordSolarTerm()
             .orElseThrow(() -> new CustomException(HttpStatus.FORBIDDEN, "등록 기간이 아닙니다."));
 
+        if (articleRepository.checkArticleRegistered(user.getId(), solarTerm.getDate().getYear(), solarTerm.getSequence())) {
+            throw new CustomException(HttpStatus.CONFLICT, "이미 등록되었습니다.");
+        }
+
         Article article = new Article(user, command.isPublished(), solarTerm.getDate().getYear(),
             solarTerm.getSequence(), command.getContents());
 


### PR DESCRIPTION
## 📟 연결된 이슈
- close #56 

## 👷 작업한 내용
- 한 절기에 기록장을 여러 개 작성하지 못하도록 변경
  - 기록장 등록 요청 시, 해당 절기에 작성된 기록장이 존재하면 409 Conflict를 응답
  - Article 테이블에 유니크 제약조건 추가 