### PR TITLE
지난 절기의 기록장은 수정하지 못하도록 변경

### DIFF
--- a/src/main/java/today/seasoning/seasoning/article/domain/Article.java
+++ b/src/main/java/today/seasoning/seasoning/article/domain/Article.java
@@ -7,6 +7,7 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import today.seasoning.seasoning.common.BaseTimeEntity;
 import today.seasoning.seasoning.common.util.TsidUtil;
+import today.seasoning.seasoning.solarterm.domain.SolarTerm;
 import today.seasoning.seasoning.user.domain.User;
 
 import javax.persistence.*;
@@ -58,5 +59,9 @@ public class Article extends BaseTimeEntity {
     public void update(boolean published, String contents) {
         this.published = published;
         this.contents = contents;
+    }
+
+    public boolean isCreatedAt(SolarTerm solarTerm) {
+        return createdYear == solarTerm.getYear() && createdTerm == solarTerm.getSequence();
     }
 }

--- a/src/main/java/today/seasoning/seasoning/article/service/UpdateArticleService.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/UpdateArticleService.java
@@ -16,6 +16,7 @@ import today.seasoning.seasoning.article.dto.UpdateArticleCommand;
 import today.seasoning.seasoning.common.aws.S3Service;
 import today.seasoning.seasoning.common.aws.UploadFileInfo;
 import today.seasoning.seasoning.common.exception.CustomException;
+import today.seasoning.seasoning.solarterm.domain.SolarTerm;
 import today.seasoning.seasoning.solarterm.service.SolarTermService;
 
 @Service
@@ -47,8 +48,12 @@ public class UpdateArticleService {
     }
 
     private void checkRequestValid(Article article, UpdateArticleCommand command) {
-        solarTermService.findRecordSolarTerm()
-            .orElseThrow(() -> new CustomException(HttpStatus.FORBIDDEN, "등록 기간이 아닙니다."));
+        SolarTerm currentRecordSolarTerm = solarTermService.findRecordSolarTerm()
+            .orElseThrow(() -> new CustomException(HttpStatus.FORBIDDEN, "작성 기간이 아닙니다."));
+
+        if (!article.isCreatedAt(currentRecordSolarTerm)) {
+            throw new CustomException(HttpStatus.FORBIDDEN, "수정 기간이 아닙니다.");
+        }
 
         Long ownerId = article.getUser().getId();
         if (!ownerId.equals(command.getUserId())) {

--- a/src/main/java/today/seasoning/seasoning/solarterm/domain/SolarTerm.java
+++ b/src/main/java/today/seasoning/seasoning/solarterm/domain/SolarTerm.java
@@ -30,4 +30,8 @@ public class SolarTerm extends BaseTimeEntity {
     public int getDaysDiff(LocalDate date) {
         return (int) Math.abs(ChronoUnit.DAYS.between(this.date, date));
     }
+
+    public int getYear() {
+        return date.getYear();
+    }
 }


### PR DESCRIPTION
## 📟 연결된 이슈
- close #58 

## 👷 작업한 내용
- 지난 절기의 기록장은 수정하지 못하도록 변경했습니다.
  
## 📸 스크린샷
<img width="439" alt="image" src="https://github.com/Seasoning-Today/backend/assets/107951175/eac4d6c5-5b5e-4d85-8ef0-36336a618b1d">
