### PR TITLE
새로운 알림 조회 API 구현

### DIFF
--- a/src/main/java/today/seasoning/seasoning/notification/controller/NotificationController.java
+++ b/src/main/java/today/seasoning/seasoning/notification/controller/NotificationController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import today.seasoning.seasoning.common.UserPrincipal;
 import today.seasoning.seasoning.notification.dto.FindNotificationCommand;
 import today.seasoning.seasoning.notification.dto.UserNotificationResponse;
+import today.seasoning.seasoning.notification.service.CheckUnreadNotificationsExistService;
 import today.seasoning.seasoning.notification.service.NotificationService;
 
 @RestController
@@ -19,6 +20,7 @@ import today.seasoning.seasoning.notification.service.NotificationService;
 public class NotificationController {
 
 	private final NotificationService notificationService;
+	private final CheckUnreadNotificationsExistService checkUnreadNotificationsExistService;
 
 	@GetMapping
 	public ResponseEntity<List<UserNotificationResponse>> findNotifications(
@@ -29,6 +31,12 @@ public class NotificationController {
 		FindNotificationCommand command = new FindNotificationCommand(principal.getId(), lastId, pageSize);
 		List<UserNotificationResponse> notifications = notificationService.findNotifications(command);
 		return ResponseEntity.ok(notifications);
+	}
+
+	@GetMapping("/new")
+	public ResponseEntity<Boolean> checkUnreadNotificationsExist(@AuthenticationPrincipal UserPrincipal principal) {
+		boolean result = checkUnreadNotificationsExistService.doService(principal.getId());
+		return ResponseEntity.ok(result);
 	}
 
 }

--- a/src/main/java/today/seasoning/seasoning/notification/controller/NotificationController.java
+++ b/src/main/java/today/seasoning/seasoning/notification/controller/NotificationController.java
@@ -12,14 +12,14 @@ import today.seasoning.seasoning.common.UserPrincipal;
 import today.seasoning.seasoning.notification.dto.FindNotificationCommand;
 import today.seasoning.seasoning.notification.dto.UserNotificationResponse;
 import today.seasoning.seasoning.notification.service.CheckUnreadNotificationsExistService;
-import today.seasoning.seasoning.notification.service.NotificationService;
+import today.seasoning.seasoning.notification.service.FindNotificationsService;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/notification")
 public class NotificationController {
 
-	private final NotificationService notificationService;
+	private final FindNotificationsService findNotificationsService;
 	private final CheckUnreadNotificationsExistService checkUnreadNotificationsExistService;
 
 	@GetMapping
@@ -29,7 +29,7 @@ public class NotificationController {
 		@RequestParam(name = "size", defaultValue = "10") Integer pageSize
 	) {
 		FindNotificationCommand command = new FindNotificationCommand(principal.getId(), lastId, pageSize);
-		List<UserNotificationResponse> notifications = notificationService.findNotifications(command);
+		List<UserNotificationResponse> notifications = findNotificationsService.doService(command);
 		return ResponseEntity.ok(notifications);
 	}
 

--- a/src/main/java/today/seasoning/seasoning/notification/domain/UserNotificationRepository.java
+++ b/src/main/java/today/seasoning/seasoning/notification/domain/UserNotificationRepository.java
@@ -13,7 +13,7 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
 
     @Modifying
     @Query("DELETE FROM UserNotification n WHERE n.senderId = :senderId AND n.receiverId = :receiverId AND n.type = :type")
-    void delete(@Param("senderId") Long sender, @Param("receiverId") Long receiverId, @Param("type") NotificationType type);
+    void delete(@Param("senderId") Long senderId, @Param("receiverId") Long receiverId, @Param("type") NotificationType type);
 
     @Query(value = "SELECT n.id as id, n.type as type, n.created_date as created, u.id as userId, u.nickname as userNickname, u.account_id as userAccountId, u.profile_image_url as userImageUrl, n.message as message, n.is_read as isRead " +
         "FROM user_notification n " +
@@ -24,7 +24,10 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
 
     @Modifying
     @Query("UPDATE UserNotification n SET n.read = true WHERE n.id = :id")
-    void markAsRead(Long id);
+    void markAsRead(@Param("id") Long id);
 
     List<UserNotification> findByReceiverId(Long receiverId);
+
+    @Query("SELECT COUNT(n) > 0 FROM UserNotification n WHERE n.receiverId = :receiverId AND n.read = false")
+    boolean checkUnreadNotificationsExist(@Param("receiverId") Long receiverId);
 }

--- a/src/main/java/today/seasoning/seasoning/notification/service/CheckUnreadNotificationsExistService.java
+++ b/src/main/java/today/seasoning/seasoning/notification/service/CheckUnreadNotificationsExistService.java
@@ -1,0 +1,18 @@
+package today.seasoning.seasoning.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import today.seasoning.seasoning.notification.domain.UserNotificationRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CheckUnreadNotificationsExistService {
+
+    private final UserNotificationRepository userNotificationRepository;
+
+    public boolean doService(Long userId) {
+        return userNotificationRepository.checkUnreadNotificationsExist(userId);
+    }
+}

--- a/src/main/java/today/seasoning/seasoning/notification/service/FindNotificationsService.java
+++ b/src/main/java/today/seasoning/seasoning/notification/service/FindNotificationsService.java
@@ -13,11 +13,11 @@ import today.seasoning.seasoning.notification.dto.UserNotificationResponse;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class NotificationService {
+public class FindNotificationsService {
 
     private final UserNotificationRepository userNotificationRepository;
 
-    public List<UserNotificationResponse> findNotifications(FindNotificationCommand command) {
+    public List<UserNotificationResponse> doService(FindNotificationCommand command) {
         List<UserNotificationProjectionInterface> projectionInterfaces = userNotificationRepository.find(
             command.getUserId(), command.getLastId(), command.getPageSize());
 

--- a/src/test/java/today/seasoning/seasoning/notification/integration/CheckUnreadNotificationsExistIntegrationTest.java
+++ b/src/test/java/today/seasoning/seasoning/notification/integration/CheckUnreadNotificationsExistIntegrationTest.java
@@ -1,0 +1,134 @@
+package today.seasoning.seasoning.notification.integration;
+
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import today.seasoning.seasoning.BaseIntegrationTest;
+import today.seasoning.seasoning.common.enums.LoginType;
+import today.seasoning.seasoning.notification.domain.NotificationType;
+import today.seasoning.seasoning.notification.domain.UserNotification;
+import today.seasoning.seasoning.notification.domain.UserNotificationRepository;
+import today.seasoning.seasoning.user.domain.User;
+import today.seasoning.seasoning.user.domain.UserRepository;
+
+@DisplayName("새로운 알림 조회 통합 테스트")
+public class CheckUnreadNotificationsExistIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    UserNotificationRepository userNotificationRepository;
+
+    @InjectSoftAssertions
+    SoftAssertions softAssertions;
+
+    static final String url = "/notification/new";
+
+    List<User> users;
+
+    @BeforeEach
+    void initMockUsers() {
+        users = userRepository.saveAll(List.of(
+            new User("userNickname0", "https://test.org/user0.jpg", "user0@email.com", LoginType.KAKAO),
+            new User("userNickname1", "https://test.org/user1.jpg", "user1@email.com", LoginType.KAKAO)
+        ));
+    }
+
+    @Test
+    @DisplayName("읽지 않은 알림이 있다면 true를 응답한다")
+    void test1() throws Exception {
+        //given : 친구 수락 알림은 읽었지만, 기록장 좋아요 알림은 읽지 않은 경우
+        User user = users.get(0);
+        User friend = users.get(1);
+
+        registerReadNotification(friend, user, NotificationType.FRIENDSHIP_ACCEPTED);
+        registerUnreadNotification(friend, user, NotificationType.ARTICLE_FEEDBACK);
+
+        //when : 새로운 알림 조회를 요청했을 때
+        ExtractableResponse<Response> response = get(url, user.getId());
+
+        boolean result = response.body().as(new TypeRef<>() {
+        });
+
+        //then
+        softAssertions.assertThat(response.statusCode())
+            .as("상태 코드는 200이어야 한다")
+            .isEqualTo(200);
+
+        softAssertions.assertThat(result)
+            .as("조회 결과는 true이어야 한다")
+            .isTrue();
+    }
+
+    @Test
+    @DisplayName("알림이 없으면 false를 응답한다")
+    void test2() throws Exception {
+        //given : 회원에게 전송된 알림이 없다면
+        User user = users.get(0);
+
+        //when : 새로운 알림 조회를 요청했을 때
+        ExtractableResponse<Response> response = get(url, user.getId());
+        boolean result = response.body().as(new TypeRef<>() {
+        });
+
+        //then
+        softAssertions.assertThat(response.statusCode())
+            .as("상태 코드는 200이어야 한다")
+            .isEqualTo(200);
+
+        softAssertions.assertThat(result)
+            .as("조회 결과는 false이어야 한다")
+            .isFalse();
+    }
+
+    @Test
+    @DisplayName("모든 알림을 읽은 경우 false를 응답한다")
+    void test3() throws Exception {
+        //given : 회원이 모든 알림을 읽었다면
+        User user = users.get(0);
+        User friend = users.get(1);
+
+        registerReadNotification(friend, user, NotificationType.FRIENDSHIP_ACCEPTED);
+        registerReadNotification(friend, user, NotificationType.ARTICLE_FEEDBACK);
+
+        //when :
+        ExtractableResponse<Response> response = get(url, user.getId());
+
+        //then
+        softAssertions.assertThat(response.statusCode())
+            .as("상태 코드는 200이어야 한다")
+            .isEqualTo(200);
+
+        boolean result = response.body().as(new TypeRef<>() {
+        });
+        softAssertions.assertThat(result)
+            .as("조회 결과는 false이어야 한다")
+            .isFalse();
+    }
+
+    private void registerReadNotification(User sender, User receiver, NotificationType type) {
+        userNotificationRepository.save(UserNotification.builder()
+            .type(type)
+            .senderId(sender.getId())
+            .receiverId(receiver.getId())
+            .read(true)
+            .build());
+    }
+
+    private void registerUnreadNotification(User sender, User receiver, NotificationType type) {
+        userNotificationRepository.save(UserNotification.builder()
+            .type(type)
+            .senderId(sender.getId())
+            .receiverId(receiver.getId())
+            .read(false)
+            .build());
+    }
+}


### PR DESCRIPTION
## 📟 연결된 이슈
- close #70 

## 👷 작업한 내용
- 새로운 알림의 존재 여부를 조회하는 API 구현
- 새로운 알림 조회 통합 테스트 작성

## 🚨 프론트 참고 사항
<img width="975" alt="image" src="https://github.com/Seasoning-Today/backend/assets/107951175/e5efebfd-4230-4e0a-9c73-837fc61384a8">


- 새로운 알림 조회 API
  - 요청 : GET /notification/new
  - 응답 : boolean
    - true : 읽지 않은 알림 존재
    - false : 모든 알림 읽음 or 알림 없음