### PR TITLE
검색 허용 기능 구현

### DIFF
--- a/src/main/java/today/seasoning/seasoning/common/exception/ErrorResponse.java
+++ b/src/main/java/today/seasoning/seasoning/common/exception/ErrorResponse.java
@@ -1,8 +1,11 @@
 package today.seasoning.seasoning.common.exception;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import lombok.Getter;
 
 @Getter
+@JsonInclude(Include.NON_NULL)
 public class ErrorResponse {
 
     private final String message;

--- a/src/main/java/today/seasoning/seasoning/friendship/service/SearchUserService.java
+++ b/src/main/java/today/seasoning/seasoning/friendship/service/SearchUserService.java
@@ -16,14 +16,18 @@ import today.seasoning.seasoning.user.domain.UserRepository;
 @RequiredArgsConstructor
 public class SearchUserService {
 
-    private final FriendRequestRepository friendRequestRepository;
-    private final FriendshipRepository friendshipRepository;
     private final UserRepository userRepository;
+    private final FriendshipRepository friendshipRepository;
+    private final FriendRequestRepository friendRequestRepository;
 
     @Transactional(readOnly = true)
     public SearchUserResult doService(Long userId, String friendAccountId) {
         User friend = userRepository.findByAccountId(friendAccountId)
-            .orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST, "회원 조회 실패"));
+            .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "검색 결과 없음"));
+
+        if (!friend.isSearchable()) {
+            throw new CustomException(HttpStatus.NOT_FOUND, "검색 결과 없음");
+        }
 
         FriendshipStatus friendshipStatus = resolveFriendshipStatus(userId, friend);
 
@@ -53,5 +57,4 @@ public class SearchUserService {
 
         return FriendshipStatus.UNFRIEND;
     }
-
 }

--- a/src/main/java/today/seasoning/seasoning/user/controller/UserController.java
+++ b/src/main/java/today/seasoning/seasoning/user/controller/UserController.java
@@ -21,6 +21,7 @@ import today.seasoning.seasoning.user.dto.UpdateUserProfileRequest;
 import today.seasoning.seasoning.user.dto.UserProfileResponse;
 import today.seasoning.seasoning.user.service.DeleteUserService;
 import today.seasoning.seasoning.user.service.FindUserProfileService;
+import today.seasoning.seasoning.user.service.FindUserSearchableStatusService;
 import today.seasoning.seasoning.user.service.UpdateUserProfileService;
 import today.seasoning.seasoning.user.service.UpdateUserSearchableStatusService;
 import today.seasoning.seasoning.user.service.VerifyAccountIdService;
@@ -36,6 +37,7 @@ public class UserController {
     private final VerifyAccountIdService verifyAccountIdService;
     private final DeleteUserService deleteUserService;
     private final UpdateUserSearchableStatusService updateUserSearchableStatusService;
+    private final FindUserSearchableStatusService findUserSearchableStatusService;
 
     // 프로필 조회
     @GetMapping("/profile")
@@ -67,6 +69,12 @@ public class UserController {
     public ResponseEntity<Void> unregister(@AuthenticationPrincipal UserPrincipal principal) {
         deleteUserService.doService(principal.getId());
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/searchable")
+    public ResponseEntity<Boolean> findSearchableStatus(@AuthenticationPrincipal UserPrincipal principal) {
+        boolean searchable = findUserSearchableStatusService.doService(principal.getId());
+        return ResponseEntity.ok(searchable);
     }
 
     @RequestMapping(value = "", method = RequestMethod.PUT, params = "searchable")

--- a/src/main/java/today/seasoning/seasoning/user/controller/UserController.java
+++ b/src/main/java/today/seasoning/seasoning/user/controller/UserController.java
@@ -2,6 +2,7 @@ package today.seasoning.seasoning.user.controller;
 
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,8 +22,10 @@ import today.seasoning.seasoning.user.dto.UserProfileResponse;
 import today.seasoning.seasoning.user.service.DeleteUserService;
 import today.seasoning.seasoning.user.service.FindUserProfileService;
 import today.seasoning.seasoning.user.service.UpdateUserProfileService;
+import today.seasoning.seasoning.user.service.UpdateUserSearchableStatusService;
 import today.seasoning.seasoning.user.service.VerifyAccountIdService;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/user")
@@ -31,6 +35,7 @@ public class UserController {
     private final FindUserProfileService findUserProfileService;
     private final VerifyAccountIdService verifyAccountIdService;
     private final DeleteUserService deleteUserService;
+    private final UpdateUserSearchableStatusService updateUserSearchableStatusService;
 
     // 프로필 조회
     @GetMapping("/profile")
@@ -61,6 +66,15 @@ public class UserController {
     @DeleteMapping
     public ResponseEntity<Void> unregister(@AuthenticationPrincipal UserPrincipal principal) {
         deleteUserService.doService(principal.getId());
+        return ResponseEntity.ok().build();
+    }
+
+    @RequestMapping(value = "", method = RequestMethod.PUT, params = "searchable")
+    public ResponseEntity<Void> updateSearchableStatus(
+        @AuthenticationPrincipal UserPrincipal principal,
+        @RequestParam("searchable") boolean searchable
+    ) {
+        updateUserSearchableStatusService.doService(principal.getId(), searchable);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/today/seasoning/seasoning/user/domain/User.java
+++ b/src/main/java/today/seasoning/seasoning/user/domain/User.java
@@ -8,6 +8,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import today.seasoning.seasoning.common.BaseTimeEntity;
 import today.seasoning.seasoning.common.aws.UploadFileInfo;
 import today.seasoning.seasoning.common.enums.LoginType;
@@ -39,9 +40,14 @@ public class User extends BaseTimeEntity {
     @Column(name = "login_type", nullable = false)
     private LoginType loginType;
 
+    @ColumnDefault("USER")
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Role role;
+
+    @ColumnDefault("true")
+    @Column(nullable = false)
+    private boolean searchable;
 
     public User(String nickname, String profileImageUrl, String email, LoginType loginType) {
         this.id = TsidCreator.getTsid().toLong();
@@ -51,6 +57,7 @@ public class User extends BaseTimeEntity {
         this.email = email;
         this.loginType = loginType;
         this.role = Role.USER;
+        this.searchable = true;
     }
 
     public void updateProfile(String nickname, String accountId) {
@@ -66,5 +73,9 @@ public class User extends BaseTimeEntity {
     public void changeProfileImage(UploadFileInfo uploadFile) {
         this.profileImageFilename = uploadFile.getFilename();
         this.profileImageUrl = uploadFile.getUrl();
+    }
+
+    public void setSearchable(boolean searchable) {
+        this.searchable = searchable;
     }
 }

--- a/src/main/java/today/seasoning/seasoning/user/service/FindUserSearchableStatusService.java
+++ b/src/main/java/today/seasoning/seasoning/user/service/FindUserSearchableStatusService.java
@@ -1,0 +1,20 @@
+package today.seasoning.seasoning.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import today.seasoning.seasoning.user.domain.User;
+import today.seasoning.seasoning.user.domain.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class FindUserSearchableStatusService {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public boolean doService(Long userId) {
+        User user = userRepository.findByIdOrElseThrow(userId);
+        return user.isSearchable();
+    }
+}

--- a/src/main/java/today/seasoning/seasoning/user/service/UpdateUserSearchableStatusService.java
+++ b/src/main/java/today/seasoning/seasoning/user/service/UpdateUserSearchableStatusService.java
@@ -1,0 +1,20 @@
+package today.seasoning.seasoning.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import today.seasoning.seasoning.user.domain.User;
+import today.seasoning.seasoning.user.domain.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateUserSearchableStatusService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void doService(Long userId, boolean searchable) {
+        User user = userRepository.findByIdOrElseThrow(userId);
+        user.setSearchable(searchable);
+    }
+}


### PR DESCRIPTION
## 📟 연결된 이슈
- close #74 

## 👷 작업한 내용
- 검색 허용 상태 조회 API 구현
- 검색 허용 상태 변경 API 구현
- 검색 허용을 비활성화 한 경우, 회원이 검색되지 않도록 구현
- 기타 : 상세 메시지가 없는 경우, 에러 응답에 detail 속성이 포함되지 않도록 변경

## 🚨 프론트 참고 사항
### 검색 허용 상태 조회 API
- 요청 : `GET /user/searchable`
- 응답 : `true | false`

### 검색 허용 상태 변경 API
- 요청 : `PUT /user?searchable={boolean}`

### 회원 검색 API
#### searchable = true
<img width="500" alt="image" src="https://github.com/Seasoning-Today/backend/assets/107951175/2e986635-7bdd-4e19-9be0-afead9fe15c6">

- 회원 검색을 허용한 경우, 정상적으로 조회됨

#### searchable = false
<img width="500" alt="image" src="https://github.com/Seasoning-Today/backend/assets/107951175/e08b7cf7-f7fe-4407-bfe0-8403a467adcf">

- 회원 검색을 불허한 경우, 404 Not Found로 응답
- 존재하지 않는 아이디로 조회한 결과와 동일함