### PR TITLE
기록장 절기별 조회 본문 미리보기 개선

### DIFF
--- a/src/main/java/today/seasoning/seasoning/article/controller/ArticleController.java
+++ b/src/main/java/today/seasoning/seasoning/article/controller/ArticleController.java
@@ -15,20 +15,20 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import today.seasoning.seasoning.article.dto.ArticlePreviewResponse;
 import today.seasoning.seasoning.article.dto.ArticleResponse;
 import today.seasoning.seasoning.article.dto.FindCollageResult;
-import today.seasoning.seasoning.article.dto.FindMyArticlesByTermResult;
-import today.seasoning.seasoning.article.dto.FindMyArticlesByYearResult;
 import today.seasoning.seasoning.article.dto.FindFriendArticleResponse;
+import today.seasoning.seasoning.article.dto.FindMyArticlesByYearResult;
 import today.seasoning.seasoning.article.dto.RegisterArticleRequest;
 import today.seasoning.seasoning.article.dto.UpdateArticleRequest;
 import today.seasoning.seasoning.article.service.ArticleLikeService;
 import today.seasoning.seasoning.article.service.DeleteArticleService;
 import today.seasoning.seasoning.article.service.FindArticleService;
-import today.seasoning.seasoning.article.service.FindCollageService;
 import today.seasoning.seasoning.article.service.FindMyArticlesByTermService;
-import today.seasoning.seasoning.article.service.FindMyArticlesByYearService;
+import today.seasoning.seasoning.article.service.FindCollageService;
 import today.seasoning.seasoning.article.service.FindFriendArticlesService;
+import today.seasoning.seasoning.article.service.FindMyArticlesByYearService;
 import today.seasoning.seasoning.article.service.RegisterArticleService;
 import today.seasoning.seasoning.article.service.UpdateArticleService;
 import today.seasoning.seasoning.common.UserPrincipal;
@@ -97,12 +97,12 @@ public class ArticleController {
     }
 
     @GetMapping("/list/term/{term}")
-    public ResponseEntity<List<FindMyArticlesByTermResult>> findMyArticlesByTerm(
+    public ResponseEntity<List<ArticlePreviewResponse>> findMyArticlesByTerm(
         @AuthenticationPrincipal UserPrincipal principal,
         @PathVariable Integer term
     ) {
-        List<FindMyArticlesByTermResult> result = findMyArticlesByTermService.doFind(principal.getId(), term);
-        return ResponseEntity.ok(result);
+        List<ArticlePreviewResponse> response = findMyArticlesByTermService.doService(principal.getId(), term);
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("{articleId}/like")

--- a/src/main/java/today/seasoning/seasoning/article/dto/ArticlePreviewResponse.java
+++ b/src/main/java/today/seasoning/seasoning/article/dto/ArticlePreviewResponse.java
@@ -1,5 +1,6 @@
 package today.seasoning.seasoning.article.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Comparator;
 import java.util.List;
@@ -38,11 +39,11 @@ public class ArticlePreviewResponse {
 		}
 
 		try {
-			ContentUnit[] contentUnits = new ObjectMapper().readValue(contents, ContentUnit[].class);
 			StringBuilder preview = new StringBuilder();
+			ArticleContent[] articleContents = new ObjectMapper().readValue(contents, ArticleContent[].class);
 
-			for (ContentUnit contentUnit : contentUnits) {
-				preview.append(contentUnit.text.replace("\n", "")).append(" ");
+			for (ArticleContent articleContent : articleContents) {
+				preview.append(articleContent.text.replace("\n", "")).append(" ");
 			}
 
 			return preview.substring(0, Math.min(preview.length() - 1, 100));
@@ -60,7 +61,8 @@ public class ArticlePreviewResponse {
 
 	@Getter
 	@Setter
-	private static class ContentUnit {
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	private static class ArticleContent {
 
 		private String type;
 		private String text;

--- a/src/main/java/today/seasoning/seasoning/article/service/FindMyArticlesByTermService.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/FindMyArticlesByTermService.java
@@ -1,53 +1,24 @@
 package today.seasoning.seasoning.article.service;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import today.seasoning.seasoning.article.domain.Article;
-import today.seasoning.seasoning.article.domain.ArticleImage;
 import today.seasoning.seasoning.article.domain.ArticleRepository;
-import today.seasoning.seasoning.article.dto.FindMyArticlesByTermResult;
-import today.seasoning.seasoning.common.util.TsidUtil;
+import today.seasoning.seasoning.article.dto.ArticlePreviewResponse;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class FindMyArticlesByTermService {
 
-	private final ArticleRepository articleRepository;
+    private final ArticleRepository articleRepository;
 
-	public List<FindMyArticlesByTermResult> doFind(Long userId, int term) {
-		return articleRepository.findByUserIdAndTerm(userId, term)
-			.stream()
-			.map(this::toDto)
-			.collect(Collectors.toList());
-	}
-
-	private FindMyArticlesByTermResult toDto(Article article) {
-		String contentsPreview = getContentsPreview(article.getContents());
-
-		String thumbnailImageUrl = getFirstImageUrl(article.getArticleImages());
-
-		return new FindMyArticlesByTermResult(
-			TsidUtil.toString(article.getId()),
-			article.getCreatedYear(),
-			contentsPreview,
-			thumbnailImageUrl);
-	}
-
-	private String getFirstImageUrl(List<ArticleImage> images) {
-		return images
-			.stream()
-			.min(Comparator.comparingInt(ArticleImage::getSequence))
-			.map(ArticleImage::getUrl)
-			.orElse(null);
-	}
-
-	private String getContentsPreview(String contents) {
-		int previewLength = Math.min(contents.length(), 150);
-		return contents.substring(0, previewLength);
-	}
+    public List<ArticlePreviewResponse> doService(Long userId, int term) {
+        return articleRepository.findByUserIdAndTerm(userId, term)
+            .stream()
+            .map(ArticlePreviewResponse::build)
+            .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
## 📟 연결된 이슈
- close #85 

## 👷 작업한 내용
- 프론트에서 내부적으로 사용하는 형식 문자가 본문 미리보기에 표시되지 않도록 개선
- 매핑의 안정성을 높이기 위해 기록장 본문 DTO에 JsonIgnoreProperties를 설정
  - 프론트에서 사용되는 컴포넌트 형식이므로 변경 가능성이 존재하여 이를 추가
