### PR TITLE
절기별 기록장 조회 : 전체 조회 기능 추가

### DIFF
--- a/src/main/java/today/seasoning/seasoning/article/controller/ArticleController.java
+++ b/src/main/java/today/seasoning/seasoning/article/controller/ArticleController.java
@@ -19,15 +19,16 @@ import today.seasoning.seasoning.article.dto.ArticlePreviewResponse;
 import today.seasoning.seasoning.article.dto.ArticleResponse;
 import today.seasoning.seasoning.article.dto.FindCollageResult;
 import today.seasoning.seasoning.article.dto.FindFriendArticleResponse;
+import today.seasoning.seasoning.article.dto.FindMyArticlesByTermCommand;
 import today.seasoning.seasoning.article.dto.FindMyArticlesByYearResult;
 import today.seasoning.seasoning.article.dto.RegisterArticleRequest;
 import today.seasoning.seasoning.article.dto.UpdateArticleRequest;
 import today.seasoning.seasoning.article.service.ArticleLikeService;
 import today.seasoning.seasoning.article.service.DeleteArticleService;
 import today.seasoning.seasoning.article.service.FindArticleService;
-import today.seasoning.seasoning.article.service.FindMyArticlesByTermService;
 import today.seasoning.seasoning.article.service.FindCollageService;
 import today.seasoning.seasoning.article.service.FindFriendArticlesService;
+import today.seasoning.seasoning.article.service.FindMyArticlesByTermService;
 import today.seasoning.seasoning.article.service.FindMyArticlesByYearService;
 import today.seasoning.seasoning.article.service.RegisterArticleService;
 import today.seasoning.seasoning.article.service.UpdateArticleService;
@@ -96,12 +97,15 @@ public class ArticleController {
         return ResponseEntity.ok(result);
     }
 
-    @GetMapping("/list/term/{term}")
+    @GetMapping("/list/term")
     public ResponseEntity<List<ArticlePreviewResponse>> findMyArticlesByTerm(
         @AuthenticationPrincipal UserPrincipal principal,
-        @PathVariable Integer term
+        @RequestParam(name = "lastId", defaultValue = "AzL8n0Y58m7") String lastArticleId,
+        @RequestParam(name = "size", defaultValue = "10") Integer pageSize,
+        @RequestParam Integer term
     ) {
-        List<ArticlePreviewResponse> response = findMyArticlesByTermService.doService(principal.getId(), term);
+        FindMyArticlesByTermCommand command = FindMyArticlesByTermCommand.build(principal, lastArticleId, pageSize, term);
+        List<ArticlePreviewResponse> response = findMyArticlesByTermService.doService(command);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/today/seasoning/seasoning/article/domain/ArticleRepository.java
+++ b/src/main/java/today/seasoning/seasoning/article/domain/ArticleRepository.java
@@ -10,8 +10,8 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 	@Query("SELECT a From Article a WHERE a.user.id = :userId AND a.createdYear = :year")
 	List<Article> findByUserIdAndYear(@Param("userId") Long userId, @Param("year") int year);
 
-	@Query("SELECT a From Article a WHERE a.user.id = :userId AND a.createdTerm = :term")
-	List<Article> findByUserIdAndTerm(@Param("userId") Long userId, @Param("term") int term);
+	@Query("SELECT a From Article a WHERE a.user.id = :userId AND a.createdTerm = :term ORDER BY a.id DESC")
+	List<Article> findByTerm(@Param("userId") Long userId, @Param("term") int term);
 
 	@Query("SELECT COUNT(a) > 0 FROM Article a WHERE a.user.id = :userId AND a.createdYear = :year AND a.createdTerm = :term")
 	boolean checkArticleRegistered(@Param("userId") Long userId, @Param("year") int year, @Param("term") int term);
@@ -23,4 +23,8 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 		"ORDER BY a.id DESC " +
 		"LIMIT :size", nativeQuery = true)
 	List<Article> findFriendArticles(@Param("userId") Long userId, @Param("articleId")Long lastArticleId, @Param("size") int pageSize);
+
+	@Query(value = "SELECT * FROM article WHERE user_id = :userId AND id < :articleId ORDER BY id DESC LIMIT :size", nativeQuery = true)
+	List<Article> findByPage(@Param("userId") Long userId, @Param("articleId") Long lastArticleId, @Param("size") int pageSize);
+
 }

--- a/src/main/java/today/seasoning/seasoning/article/dto/ArticlePreviewResponse.java
+++ b/src/main/java/today/seasoning/seasoning/article/dto/ArticlePreviewResponse.java
@@ -53,6 +53,10 @@ public class ArticlePreviewResponse {
 	}
 
 	private static String getFirstImageUrl(List<ArticleImage> images) {
+		if (images == null || images.isEmpty()) {
+			return null;
+		}
+
 		return images.stream()
 			.min(Comparator.comparingInt(ArticleImage::getSequence))
 			.map(ArticleImage::getUrl)

--- a/src/main/java/today/seasoning/seasoning/article/dto/FindMyArticlesByTermCommand.java
+++ b/src/main/java/today/seasoning/seasoning/article/dto/FindMyArticlesByTermCommand.java
@@ -1,0 +1,20 @@
+package today.seasoning.seasoning.article.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import today.seasoning.seasoning.common.UserPrincipal;
+import today.seasoning.seasoning.common.util.TsidUtil;
+
+@Getter
+@RequiredArgsConstructor
+public class FindMyArticlesByTermCommand {
+
+    private final Long userId;
+    private final Long lastArticleId;
+    private final int size;
+    private final int term;
+
+    public static FindMyArticlesByTermCommand build(UserPrincipal userPrincipal, String lastArticleId, Integer pageSize, Integer term) {
+        return new FindMyArticlesByTermCommand(userPrincipal.getId(), TsidUtil.toLong(lastArticleId), pageSize, term);
+    }
+}

--- a/src/main/java/today/seasoning/seasoning/article/service/FindMyArticlesByTermService.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/FindMyArticlesByTermService.java
@@ -5,8 +5,10 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import today.seasoning.seasoning.article.domain.Article;
 import today.seasoning.seasoning.article.domain.ArticleRepository;
 import today.seasoning.seasoning.article.dto.ArticlePreviewResponse;
+import today.seasoning.seasoning.article.dto.FindMyArticlesByTermCommand;
 
 @Service
 @RequiredArgsConstructor
@@ -15,10 +17,11 @@ public class FindMyArticlesByTermService {
 
     private final ArticleRepository articleRepository;
 
-    public List<ArticlePreviewResponse> doService(Long userId, int term) {
-        return articleRepository.findByUserIdAndTerm(userId, term)
-            .stream()
-            .map(ArticlePreviewResponse::build)
-            .collect(Collectors.toList());
+    public List<ArticlePreviewResponse> doService(FindMyArticlesByTermCommand command) {
+        List<Article> articles = command.getTerm() > 0 ?
+            articleRepository.findByTerm(command.getUserId(), command.getTerm()) :
+            articleRepository.findByPage(command.getUserId(), command.getLastArticleId(), command.getSize());
+
+        return articles.stream().map(ArticlePreviewResponse::build).collect(Collectors.toList());
     }
 }

--- a/src/test/java/today/seasoning/seasoning/article/integration/FindMyArticlesByTermIntegrationTest.java
+++ b/src/test/java/today/seasoning/seasoning/article/integration/FindMyArticlesByTermIntegrationTest.java
@@ -1,0 +1,101 @@
+package today.seasoning.seasoning.article.integration;
+
+import static java.util.stream.Collectors.toList;
+
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import today.seasoning.seasoning.BaseIntegrationTest;
+import today.seasoning.seasoning.article.domain.Article;
+import today.seasoning.seasoning.article.domain.ArticleRepository;
+import today.seasoning.seasoning.article.dto.ArticlePreviewResponse;
+import today.seasoning.seasoning.common.enums.LoginType;
+import today.seasoning.seasoning.user.domain.User;
+import today.seasoning.seasoning.user.domain.UserRepository;
+
+@DisplayName("절기별 기록장 조회")
+public class FindMyArticlesByTermIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    ArticleRepository articleRepository;
+
+    @InjectSoftAssertions
+    SoftAssertions softAssertions;
+
+    String url = "/article/list/term";
+
+    User user;
+    List<Article> articles;
+
+    @BeforeEach
+    void init() {
+        user = userRepository.save(new User("user", "image", "email@test.org", LoginType.KAKAO));
+
+        articles = articleRepository.saveAll(List.of(
+            new Article(user, true, 2023, 1, null),
+            new Article(user, true, 2023, 5, ""),
+            new Article(user, true, 2024, 1, ""),
+            new Article(user, true, 2024, 7, ""),
+            new Article(user, true, 2025, 1, "")
+        ));
+    }
+
+    @Test
+    @DisplayName("절기 미선택 시, 전체 기록장을 최신순으로 조회한다")
+    void test1() {
+        //given
+        int term = 0;
+
+        //when
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("term", term);
+
+        ExtractableResponse<Response> response = get(url, user.getId(), params);
+        List<ArticlePreviewResponse> articleResponses = response.body().as(new TypeRef<>() {
+        });
+
+        //then
+        List<ArticlePreviewResponse> expected = articles.stream()
+            .sorted(Comparator.comparingLong(Article::getId).reversed())
+            .map(ArticlePreviewResponse::build)
+            .collect(toList());
+
+        softAssertions.assertThat(articleResponses)
+            .usingRecursiveComparison()
+            .isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("절기 선택 시, 해당 절기의 기록장을 최신순으로 조회한다")
+    void test2() {
+        //given
+        int term = 1;
+
+        //when
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("term", term);
+
+        ExtractableResponse<Response> response = get(url, user.getId(), params);
+        List<ArticlePreviewResponse> articleResponses = response.body().as(new TypeRef<>() {
+        });
+
+        //then
+        softAssertions.assertThat(articleResponses.stream().allMatch(a -> a.getTerm() == term)).isTrue();
+
+        softAssertions.assertThat(articleResponses.stream().map(ArticlePreviewResponse::getYear).collect(toList()))
+            .usingRecursiveComparison()
+            .isEqualTo(List.of(2025, 2024, 2023));
+    }
+}


### PR DESCRIPTION
## 📟 연결된 이슈
- close #88 

## 👷 작업한 내용
- 절기별 기록장 조회 시, 절기를 선택하지 않으면(term = 0) 기록장을 최신순으로 조회하는 기능 추가
- 절기별 기록장 조회 통합 테스트 작성

## 🚨 프론트 참고 사항
- 요청 매개변수 전달 방식 변경 : Path Variable -> Query Parameter
  - Before : /article/list/term/{term}
  - After : /article/list
    - term : 선택된 절기 번호
    - lastId: 마지막으로 조회한 기록장의 아이디 (첫 페이지 조회 시 생략)
    - size: 페이지 크기 (생략 가능, 기본값 10)
  - lastId와 size는 페이징에 사용되는 변수 입니다.
  - 페이징은 전체 조회(term=0)에만 적용되고, 절기를 선택한 경우에는 적용되지 않습니다.
    - 즉, term이 0이 아닌 경우 lastId와 size는 무시되기 때문에 필요하지 않습니다.