### PR TITLE
타임존 설정

### DIFF
--- a/src/main/java/today/seasoning/seasoning/SeasoningApplication.java
+++ b/src/main/java/today/seasoning/seasoning/SeasoningApplication.java
@@ -1,5 +1,7 @@
 package today.seasoning.seasoning;
 
+import java.util.TimeZone;
+import javax.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -8,8 +10,13 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication
 public class SeasoningApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(SeasoningApplication.class, args);
-	}
+    @PostConstruct
+    public void setTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(SeasoningApplication.class, args);
+    }
 
 }


### PR DESCRIPTION
## 📟 연결된 이슈
- #90 

## 👷 작업한 내용
- 서버 시간이 한국 시간과 9시간 차이나는 문제가 발생하여, 타임존을 명시적으로 서울로 지정