### PR TITLE
타임존 설정 취소

### DIFF
--- a/src/main/java/today/seasoning/seasoning/SeasoningApplication.java
+++ b/src/main/java/today/seasoning/seasoning/SeasoningApplication.java
@@ -1,7 +1,5 @@
 package today.seasoning.seasoning;
 
-import java.util.TimeZone;
-import javax.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -9,11 +7,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 @SpringBootApplication
 public class SeasoningApplication {
-
-    @PostConstruct
-    public void setTimeZone() {
-        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
-    }
 
     public static void main(String[] args) {
         SpringApplication.run(SeasoningApplication.class, args);


### PR DESCRIPTION


## 📟 연결된 이슈
- close #90 

## 👷 작업한 내용
- 시간 차이의 원인이 서버 시간이 아닌 DB 시간이 UTC로 설정되어 있었기 때문이므로 이를 취소
- Datasource의 serverTimezone을 Asia/Seoul로 설정함
