### PR TITLE
fix: 기록장 좋아요 취소 오류 해결

### DIFF
--- a/src/main/java/today/seasoning/seasoning/article/service/ArticleLikeService.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/ArticleLikeService.java
@@ -37,19 +37,17 @@ public class ArticleLikeService {
 			articleLikeRepository.save(new ArticleLike(article, user));
 
 			if (user != author) {
-				applicationEventPublisher.publishEvent(new ArticleLikedEvent(user.getId(), author.getId(), articleId));
+				ArticleLikedEvent articleLikedEvent = new ArticleLikedEvent(user.getId(), author.getId(), articleId);
+				applicationEventPublisher.publishEvent(articleLikedEvent);
 			}
 		}
 	}
 
 	public void cancelLike(Long userId, Long articleId) {
 		Article article = articleRepository.findByIdOrElseThrow(articleId);
-
 		validatePermission(userId, article);
-
-		if(articleLikeRepository.findByArticleAndUser(articleId, userId).isPresent()) {
-			articleLikeRepository.deleteById(articleId);
-		}
+		articleLikeRepository.findByArticleAndUser(articleId, userId)
+			.ifPresent(articleLike -> articleLikeRepository.deleteById(articleLike.getId()));
 	}
 
 	private void validatePermission(Long userId, Article article) {


### PR DESCRIPTION
## 👷 작업한 내용
- 기록장 좋아요 취소 오류 해결
  - 원인 :  삭제할 기록장 좋아요 엔티티 식별자 지정 오류
  - 해결
    - before : articleLikeRepository.deleteById(articleId); 
    - after : articleLikeRepository.deleteById(articleLikeId);

