### PR TITLE
최초 랜덤 아이디 생성값을 소문자로 변경

### DIFF
--- a/src/main/java/today/seasoning/seasoning/user/domain/User.java
+++ b/src/main/java/today/seasoning/seasoning/user/domain/User.java
@@ -53,7 +53,7 @@ public class User extends BaseTimeEntity {
         this.id = TsidCreator.getTsid().toLong();
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
-        this.accountId = TsidCreator.getTsid().toString(); // 최초 랜덤값 부여
+        this.accountId = TsidCreator.getTsid().toString().toLowerCase(); // 최초 랜덤값 부여
         this.email = email;
         this.loginType = loginType;
         this.role = Role.USER;


### PR DESCRIPTION
## 👷 작업한 내용
- 아이디 정책상 대문자를 허용하지 않기 때문에, 최초 생성된 랜덤 아이디 값을 소문자로 변경