### PR TITLE
기록장 암호화 적용

### DIFF
--- a/src/main/java/today/seasoning/seasoning/article/domain/Article.java
+++ b/src/main/java/today/seasoning/seasoning/article/domain/Article.java
@@ -3,6 +3,7 @@ package today.seasoning.seasoning.article.domain;
 import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
@@ -20,6 +21,7 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import today.seasoning.seasoning.article.dto.RegisterArticleCommand;
 import today.seasoning.seasoning.common.BaseTimeEntity;
+import today.seasoning.seasoning.common.cipher.CryptoConverter;
 import today.seasoning.seasoning.common.util.TsidUtil;
 import today.seasoning.seasoning.solarterm.domain.SolarTerm;
 import today.seasoning.seasoning.user.domain.User;
@@ -49,6 +51,7 @@ public class Article extends BaseTimeEntity {
     private int createdTerm;
 
     @Lob
+    @Convert(converter = CryptoConverter.class)
     private String contents;
 
     @OneToMany(mappedBy = "article", cascade = {CascadeType.REMOVE, CascadeType.PERSIST}, orphanRemoval = true)

--- a/src/main/java/today/seasoning/seasoning/common/cipher/CipherProperties.java
+++ b/src/main/java/today/seasoning/seasoning/common/cipher/CipherProperties.java
@@ -1,0 +1,18 @@
+package today.seasoning.seasoning.common.cipher;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "cipher")
+public class CipherProperties {
+
+    private String secretKey;
+    private String algorithm;
+    private String transformation;
+    private String iv;
+}

--- a/src/main/java/today/seasoning/seasoning/common/cipher/CipherUtil.java
+++ b/src/main/java/today/seasoning/seasoning/common/cipher/CipherUtil.java
@@ -1,0 +1,58 @@
+package today.seasoning.seasoning.common.cipher;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.binary.Base64;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CipherUtil {
+
+    private final Cipher cipher;
+    private final SecretKeySpec secretKeySpec;
+    private final IvParameterSpec ivParameterSpec;
+
+    @Autowired
+    public CipherUtil(CipherProperties properties) throws NoSuchPaddingException, NoSuchAlgorithmException {
+        this.secretKeySpec = new SecretKeySpec(properties.getSecretKey().getBytes(UTF_8), properties.getAlgorithm());
+        this.ivParameterSpec = new IvParameterSpec(properties.getIv().getBytes());
+        this.cipher = Cipher.getInstance(properties.getTransformation());
+    }
+
+    public String encode(String plainText) {
+        if (plainText == null) {
+            return null;
+        }
+
+        try {
+            cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, ivParameterSpec);
+            byte[] encrypted = cipher.doFinal(plainText.getBytes(UTF_8));
+            return Base64.encodeBase64String(encrypted);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String decode(String encodedText) {
+        if (encodedText == null) {
+            return null;
+        }
+
+        try {
+            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, ivParameterSpec);
+            byte[] decoded = cipher.doFinal(Base64.decodeBase64(encodedText));
+            return new String(decoded, UTF_8);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/java/today/seasoning/seasoning/common/cipher/CryptoConverter.java
+++ b/src/main/java/today/seasoning/seasoning/common/cipher/CryptoConverter.java
@@ -1,0 +1,22 @@
+package today.seasoning.seasoning.common.cipher;
+
+import javax.persistence.AttributeConverter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CryptoConverter implements AttributeConverter<String, String> {
+
+    private final CipherUtil cipherUtil;
+
+    @Override
+    public String convertToDatabaseColumn(String attribute) {
+        return cipherUtil.encode(attribute);
+    }
+
+    @Override
+    public String convertToEntityAttribute(String dbData) {
+        return cipherUtil.decode(dbData);
+    }
+}


### PR DESCRIPTION
## 👷 작업한 내용
- DB에 기록장의 내용을 암호화하여 저장하도록 변경
- 암/복호화는 JPA AttributeConverter를 기반으로 구현

## 🚨 참고 사항
[JPA AttributeConverter를 사용하여 자동으로 변환된 값을 바인딩하기
](https://rachel0115.tistory.com/entry/JPA-JPA-AttributeConverter%EB%A5%BC-%EC%82%AC%EC%9A%A9%ED%95%98%EC%97%AC-%EC%9E%90%EB%8F%99%EC%9C%BC%EB%A1%9C-%EA%B0%92%EC%9D%84-%EB%B3%80%ED%99%98%ED%95%98%EA%B8%B0)