### PR TITLE
Amazon SNS 토픽 메시지 전송 AOP 구현

### DIFF
--- a/src/main/java/today/seasoning/seasoning/common/aspect/ReportResultToSnsTopic.java
+++ b/src/main/java/today/seasoning/seasoning/common/aspect/ReportResultToSnsTopic.java
@@ -1,0 +1,15 @@
+package today.seasoning.seasoning.common.aspect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// Amazon SNS Topic으로 실행 결과를 전송할 메서드에 붙이는 어노테이션
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ReportResultToSnsTopic {
+
+    String name(); // 결과를 보고할 작업의 이름
+}

--- a/src/main/java/today/seasoning/seasoning/common/aspect/ReportResultToSnsTopicAspect.java
+++ b/src/main/java/today/seasoning/seasoning/common/aspect/ReportResultToSnsTopicAspect.java
@@ -1,0 +1,31 @@
+package today.seasoning.seasoning.common.aspect;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import today.seasoning.seasoning.common.aws.SnsService;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class ReportResultToSnsTopicAspect {
+
+    private final SnsService snsService;
+
+    @Pointcut("@annotation(reportResultToSnsTopic)")
+    public void reportResultToSnsTopicPointCut(ReportResultToSnsTopic reportResultToSnsTopic) {
+    }
+
+    @AfterReturning(value = "reportResultToSnsTopicPointCut(reportResultToSnsTopic)")
+    public void reportSuccessResult(ReportResultToSnsTopic reportResultToSnsTopic) {
+        snsService.publish("[시즈닝] " + reportResultToSnsTopic.name() + " 성공");
+    }
+
+    @AfterThrowing(value = "reportResultToSnsTopicPointCut(reportResultToAmazonSnsTopic)", throwing = "exception")
+    public void reportFailureResult(ReportResultToSnsTopic reportResultToAmazonSnsTopic, Exception exception) {
+        snsService.publish("[시즈닝] " + reportResultToAmazonSnsTopic.name() + " 실패");
+    }
+}

--- a/src/main/java/today/seasoning/seasoning/solarterm/service/scheduled/RegisterNextYearSolarTermsService.java
+++ b/src/main/java/today/seasoning/seasoning/solarterm/service/scheduled/RegisterNextYearSolarTermsService.java
@@ -4,27 +4,19 @@ import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import today.seasoning.seasoning.common.aws.SnsService;
+import today.seasoning.seasoning.common.aspect.ReportResultToSnsTopic;
 import today.seasoning.seasoning.solarterm.service.RegisterSolarTermsService;
 
 @Service
 @RequiredArgsConstructor
 public class RegisterNextYearSolarTermsService {
 
-    private final SnsService snsService;
     private final RegisterSolarTermsService registerSolarTermsService;
 
     @Scheduled(cron = "0 0 0 1 12 *")
+    @ReportResultToSnsTopic(name = "절기 등록 작업")
     public void doService() {
-        int nextYear = LocalDate.now().getYear() + 1;
-
-        try {
-            registerSolarTermsService.doService(nextYear);
-
-            snsService.publish("[시즈닝] " + nextYear + "년 절기 등록 완료");
-        } catch (Exception e) {
-            snsService.publish("[시즈닝] ERROR - " + nextYear + "년 절기 등록 실패");
-        }
+        registerSolarTermsService.doService(LocalDate.now().getYear() + 1);
     }
 
 }


### PR DESCRIPTION
## 📟 연결된 이슈
- close #15 

## 👷 작업한 내용
- 메서드의 실행 결과를 Amazon SNS 토픽으로 전송하는 AOP 구현
- 절기 등록 스케줄링 작업에 해당 AOP를 적용하여 서비스 로직으로부터 SnsService에 대한 의존성을 제거
