### PR TITLE
프로필 이미지 썸네일 기능 구현

### DIFF
--- a/src/main/java/today/seasoning/seasoning/article/service/RegisterArticleService.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/RegisterArticleService.java
@@ -64,7 +64,7 @@ public class RegisterArticleService {
         int sequence = 1;
         for (MultipartFile image : images) {
             if (image != null && !image.isEmpty()) {
-                UploadFileInfo fileInfo = s3Service.uploadFile(image);
+                UploadFileInfo fileInfo = s3Service.uploadArticleImage(image);
                 articleImageRepository.save(ArticleImage.build(article, fileInfo, sequence++));
             }
         }

--- a/src/main/java/today/seasoning/seasoning/article/service/UpdateArticleService.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/UpdateArticleService.java
@@ -74,7 +74,7 @@ public class UpdateArticleService {
             if (image == null || image.isEmpty()) {
                 continue;
             }
-            UploadFileInfo fileInfo = s3Service.uploadFile(image);
+            UploadFileInfo fileInfo = s3Service.uploadArticleImage(image);
             articleImageRepository.save(ArticleImage.build(article, fileInfo, sequence++));
         }
     }

--- a/src/main/java/today/seasoning/seasoning/common/aws/S3Service.java
+++ b/src/main/java/today/seasoning/seasoning/common/aws/S3Service.java
@@ -19,32 +19,64 @@ public class S3Service {
 	private final AmazonS3 amazonS3;
 
 	@Value("${cloud.aws.s3.bucket}")
-	private String s3BucketName;
+	private String BUCKET_NAME;
 
 	@Value("${cloud.aws.cloudfront.distribution.url}")
-	private String cloudfrontUrl;
+	private String CLOUDFRONT_DISTRIBUTION_URL;
 
-	public UploadFileInfo uploadFile(MultipartFile multipartFile) {
-		String filename = TsidCreator.getTsid().encode(62) + "/" + multipartFile.getOriginalFilename();
+	@Value("${cloud.aws.s3.image.prefix.original}")
+	private String ORIGINAL_PREFIX;
 
+	@Value("${cloud.aws.s3.image.prefix.resized}")
+	private String RESIZED_PREFIX;
+
+	@Value("${cloud.aws.s3.image.prefix.profile}")
+	private String PROFILE_IMAGE_PREFIX;
+
+	@Value("${cloud.aws.s3.image.prefix.article}")
+	private String ARTICLE_IMAGE_PREFIX;
+
+	public UploadFileInfo uploadProfileImage(MultipartFile multipartFile) {
+		String key = ORIGINAL_PREFIX + PROFILE_IMAGE_PREFIX + getUIDPrefix() + multipartFile.getOriginalFilename();
+		return uploadFile(multipartFile, key, true);
+	}
+
+	public UploadFileInfo uploadArticleImage(MultipartFile multipartFile) {
+		String key = ORIGINAL_PREFIX + ARTICLE_IMAGE_PREFIX + getUIDPrefix() + multipartFile.getOriginalFilename();
+		return uploadFile(multipartFile, key, false);
+	}
+
+	private UploadFileInfo uploadFile(MultipartFile multipartFile, String key, boolean resized) {
 		ObjectMetadata metadata = new ObjectMetadata();
 		metadata.setContentLength(multipartFile.getSize());
 		metadata.setContentType(multipartFile.getContentType());
 
 		try {
-			amazonS3.putObject(s3BucketName, filename, multipartFile.getInputStream(), metadata);
-			return new UploadFileInfo(filename, cloudfrontUrl.concat(filename));
+			amazonS3.putObject(BUCKET_NAME, key, multipartFile.getInputStream(), metadata);
 		} catch (Exception e) {
-			log.error("Uploading File Failed : {} - {}", filename, e.getMessage());
+			log.error("S3 Upload Failed - key : {} / message : {}", key, e.getMessage());
 			throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드 실패");
+		}
+
+		if(resized) {
+			return new UploadFileInfo(key, CLOUDFRONT_DISTRIBUTION_URL + resolveResizedObjectKey(key));
+		}
+		return new UploadFileInfo(key, CLOUDFRONT_DISTRIBUTION_URL + key);
+	}
+
+	public void deleteFile(String key) {
+		try {
+			amazonS3.deleteObject(BUCKET_NAME, key);
+		} catch (Exception e) {
+			log.error("S3 Delete Failed - key : {} / message : {}", key, e.getMessage());
 		}
 	}
 
-	public void deleteFile(String filename) {
-		try {
-			amazonS3.deleteObject(s3BucketName, filename);
-		} catch (Exception e) {
-			log.error("Deleting File Failed : {} - {}", filename, e.getMessage());
-		}
+	private String getUIDPrefix() {
+		return TsidCreator.getTsid().encode(62) + "_";
+	}
+
+	private String resolveResizedObjectKey(String originalKey) {
+		return originalKey.replaceFirst(ORIGINAL_PREFIX, RESIZED_PREFIX);
 	}
 }

--- a/src/main/java/today/seasoning/seasoning/common/aws/S3Service.java
+++ b/src/main/java/today/seasoning/seasoning/common/aws/S3Service.java
@@ -2,7 +2,7 @@ package today.seasoning.seasoning.common.aws;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.github.f4b6a3.tsid.TsidCreator;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,12 +37,12 @@ public class S3Service {
 	private String ARTICLE_IMAGE_PREFIX;
 
 	public UploadFileInfo uploadProfileImage(MultipartFile multipartFile) {
-		String key = ORIGINAL_PREFIX + PROFILE_IMAGE_PREFIX + getUIDPrefix() + multipartFile.getOriginalFilename();
+		String key = buildKey(PROFILE_IMAGE_PREFIX);
 		return uploadFile(multipartFile, key, true);
 	}
 
 	public UploadFileInfo uploadArticleImage(MultipartFile multipartFile) {
-		String key = ORIGINAL_PREFIX + ARTICLE_IMAGE_PREFIX + getUIDPrefix() + multipartFile.getOriginalFilename();
+		String key = buildKey(ARTICLE_IMAGE_PREFIX);
 		return uploadFile(multipartFile, key, false);
 	}
 
@@ -72,8 +72,8 @@ public class S3Service {
 		}
 	}
 
-	private String getUIDPrefix() {
-		return TsidCreator.getTsid().encode(62) + "_";
+	private String buildKey(String prefix) {
+		return ORIGINAL_PREFIX + prefix + UUID.randomUUID();
 	}
 
 	private String resolveResizedObjectKey(String originalKey) {

--- a/src/main/java/today/seasoning/seasoning/user/service/UpdateUserProfileService.java
+++ b/src/main/java/today/seasoning/seasoning/user/service/UpdateUserProfileService.java
@@ -43,7 +43,7 @@ public class UpdateUserProfileService {
         if (image == null || image.isEmpty()) {
             user.removeProfileImage();
         } else {
-            UploadFileInfo uploadFileInfo = s3Service.uploadFile(image);
+            UploadFileInfo uploadFileInfo = s3Service.uploadProfileImage(image);
             user.changeProfileImage(uploadFileInfo);
         }
 


### PR DESCRIPTION
## 📟 연결된 이슈
- close #106 

## 👷 작업한 내용
- S3 업로드 시, 썸네일 이미지를 생성하는 람다 함수가 트리거 되도록 설정
  - 원본 이미지 경로 : origin/~
  - 썸네일 이미지 경로 : resize/~
- 기본적으로 프로필 이미지 주소로 썸네일 이미지 주소를 응답
  - 썸네일 생성 지연 및 실패 등의 이유로 다운로드 실패 시, prefix를 변경하여 원본 이미지를 조회하도록 프론트측과 함께 조율

## 🚨 작업 내용
- https://csct3434.tistory.com/187
