### PR TITLE
Amazon SNS Topic 메시지 전송 관심사를 Aspect로 분리

### DIFF
--- a/src/main/java/today/seasoning/seasoning/common/aspect/NotifyResult.java
+++ b/src/main/java/today/seasoning/seasoning/common/aspect/NotifyResult.java
@@ -1,0 +1,15 @@
+package today.seasoning.seasoning.common.aspect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// Amazon SNS Topic으로 실행 결과를 전송할 메서드에 붙이는 어노테이션
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NotifyResult {
+
+    // 작업명
+    String name();
+}

--- a/src/main/java/today/seasoning/seasoning/common/aspect/NotifyResultAspect.java
+++ b/src/main/java/today/seasoning/seasoning/common/aspect/NotifyResultAspect.java
@@ -1,0 +1,26 @@
+package today.seasoning.seasoning.common.aspect;
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import today.seasoning.seasoning.common.aws.SnsService;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class NotifyResultAspect {
+
+    private final SnsService snsService;
+
+    @AfterReturning(pointcut = "@annotation(notifyResult)")
+    public void reportSuccessResult(NotifyResult notifyResult) {
+        snsService.publish("[시즈닝] " + notifyResult.name() + " 완료");
+    }
+
+    @AfterThrowing(pointcut = "@annotation(notifyResult)")
+    public void reportFailureResult(NotifyResult notifyResult) {
+        snsService.publish("[시즈닝] " + notifyResult.name() + " 실패");
+    }
+}

--- a/src/main/java/today/seasoning/seasoning/solarterm/service/scheduled/RegisterNextYearSolarTermsService.java
+++ b/src/main/java/today/seasoning/seasoning/solarterm/service/scheduled/RegisterNextYearSolarTermsService.java
@@ -4,27 +4,20 @@ import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import today.seasoning.seasoning.common.aws.SnsService;
+import today.seasoning.seasoning.common.aspect.NotifyResult;
 import today.seasoning.seasoning.solarterm.service.RegisterSolarTermsService;
 
 @Service
 @RequiredArgsConstructor
 public class RegisterNextYearSolarTermsService {
 
-    private final SnsService snsService;
     private final RegisterSolarTermsService registerSolarTermsService;
 
     @Scheduled(cron = "0 0 0 1 12 *")
+    @NotifyResult(name = "절기 등록 작업")
     public void doService() {
         int nextYear = LocalDate.now().getYear() + 1;
-
-        try {
-            registerSolarTermsService.doService(nextYear);
-
-            snsService.publish("[시즈닝] " + nextYear + "년 절기 등록 완료");
-        } catch (Exception e) {
-            snsService.publish("[시즈닝] ERROR - " + nextYear + "년 절기 등록 실패");
-        }
+        registerSolarTermsService.doService(nextYear);
     }
 
 }


### PR DESCRIPTION
## 📟 연결된 이슈
- close #15 

## 👷 작업한 내용
- 메서드의 실행 결과를 Amazon SNS 토픽으로 전송하는 NotifyResyltAspect 구현
- 해당 Aspect를 활용하여 절기 등록 스케줄링 작업으로부터 알림 전송 관심사를 분리
