### PR TITLE
액세스 로그 기록 위치 변경

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -13,7 +13,7 @@ logging:
 
 server:
   tomcat:
-    basedir: .
+    basedir: /home/ubuntu/app
     accesslog:
       enabled: true
       pattern: "%h %l %u %t \"%r\" %s %b %D"


### PR DESCRIPTION
## 📟 연결된 이슈
#119 

## 👷 작업한 내용
- server.tomcat.basedir를 현재 위치로 지정 시, CodeDeploy Agent에 의해 액세스 로그가 /opt/codedeploy-agent 하위에 저장되는 현상 발생
- 이에 basedir를 절대 경로로 지정
