### PR TITLE
액세스 로그 서블릿 필터 추가

### DIFF
--- a/src/main/java/today/seasoning/seasoning/SeasoningApplication.java
+++ b/src/main/java/today/seasoning/seasoning/SeasoningApplication.java
@@ -7,10 +7,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.ServletComponentScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Slf4j
 @EnableScheduling
+@ServletComponentScan
 @SpringBootApplication
 public class SeasoningApplication {
 

--- a/src/main/java/today/seasoning/seasoning/common/config/AccessLogFilter.java
+++ b/src/main/java/today/seasoning/seasoning/common/config/AccessLogFilter.java
@@ -1,0 +1,26 @@
+package today.seasoning.seasoning.common.config;
+
+
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import org.springframework.beans.factory.annotation.Value;
+
+@WebFilter(urlPatterns = "/monitoring/*")
+public class AccessLogFilter implements Filter {
+
+    @Value("${server.tomcat.accesslog.condition-unless}")
+    private String conditionUnlessKey;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws ServletException, IOException {
+        request.setAttribute(conditionUnlessKey, conditionUnlessKey);
+        chain.doFilter(request, response);
+    }
+
+}


### PR DESCRIPTION
## 📟 연결된 이슈
- #119

## 👷 작업한 내용
- 액세스 로그가 헬스 체크 요청으로 도배되는 현상 발생
- 액세스 로그를 기록하지 않을 요청에 특정 attribute를 추가하는 서블릿 필터 구현
- server.tomcat.accesslog.condition-unless 설정을 통해 특정 attribute를 보유한 요청은 액세스 로그를 남기지 기록하지 처리