### PR TITLE
회원가입 이벤트 관련 코드 리팩토링

### DIFF
--- a/src/main/java/today/seasoning/seasoning/friendship/event/handler/SignedUpEventHandler.java
+++ b/src/main/java/today/seasoning/seasoning/friendship/event/handler/SignedUpEventHandler.java
@@ -1,4 +1,4 @@
-package today.seasoning.seasoning.user.event;
+package today.seasoning.seasoning.friendship.event.handler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,11 +12,12 @@ import today.seasoning.seasoning.friendship.domain.Friendship;
 import today.seasoning.seasoning.friendship.domain.FriendshipRepository;
 import today.seasoning.seasoning.user.domain.User;
 import today.seasoning.seasoning.user.domain.UserRepository;
+import today.seasoning.seasoning.user.event.SignedUpEvent;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class SignUpEventHandler {
+public class SignedUpEventHandler {
 
     @Value("${OFFICIAL_ACCOUNT_USER_ID}")
     private Long officialAccountUserId;
@@ -26,11 +27,11 @@ public class SignUpEventHandler {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void addOfficialAccountFriend(SignUpEvent event) {
-        User signUpUser = event.getSignUpUser();
+    public void addOfficialAccountFriend(SignedUpEvent event) {
+        User signedUpUser = event.getSignedUpUser();
         User officialUser = userRepository.findByIdOrElseThrow(officialAccountUserId);
-        friendshipRepository.save(new Friendship(signUpUser, officialUser));
-        friendshipRepository.save(new Friendship(officialUser, signUpUser));
-        log.info("Sign Up Event - User {}", signUpUser.getId());
+        friendshipRepository.save(new Friendship(signedUpUser, officialUser));
+        friendshipRepository.save(new Friendship(officialUser, signedUpUser));
+        log.info("New User Signed Up {}", signedUpUser.getId());
     }
 }

--- a/src/main/java/today/seasoning/seasoning/user/event/SignedUpEvent.java
+++ b/src/main/java/today/seasoning/seasoning/user/event/SignedUpEvent.java
@@ -6,8 +6,8 @@ import today.seasoning.seasoning.user.domain.User;
 
 @Getter
 @RequiredArgsConstructor
-public class SignUpEvent {
+public class SignedUpEvent {
 
-    private final User signUpUser;
+    private final User signedUpUser;
 
 }

--- a/src/main/java/today/seasoning/seasoning/user/service/kakao/KakaoLoginService.java
+++ b/src/main/java/today/seasoning/seasoning/user/service/kakao/KakaoLoginService.java
@@ -16,7 +16,7 @@ import today.seasoning.seasoning.user.dto.LoginResult;
 import today.seasoning.seasoning.user.dto.SocialUserProfileDto;
 
 import java.util.Optional;
-import today.seasoning.seasoning.user.event.SignUpEvent;
+import today.seasoning.seasoning.user.event.SignedUpEvent;
 
 @Slf4j
 @Service
@@ -50,7 +50,7 @@ public class KakaoLoginService {
 
         if (foundUser.isEmpty()) {
             User user = userRepository.save(userProfile.toEntity(LoginType.KAKAO));
-            eventPublisher.publishEvent(new SignUpEvent(user));
+            eventPublisher.publishEvent(new SignedUpEvent(user));
             return new LoginInfo(user, true);
         }
         return new LoginInfo(foundUser.get(), false);

--- a/src/test/java/today/seasoning/seasoning/user/event/SignedUpEventHandlerIntegrationTest.java
+++ b/src/test/java/today/seasoning/seasoning/user/event/SignedUpEventHandlerIntegrationTest.java
@@ -18,7 +18,7 @@ import today.seasoning.seasoning.user.domain.UserRepository;
 
 @DisplayName("회원가입 이벤트 핸들러 통합 테스트")
 @Sql(scripts = "classpath:data/insert_official_account_user.sql")
-class SignUpEventHandlerIntegrationTest extends BaseIntegrationTest {
+class SignedUpEventHandlerIntegrationTest extends BaseIntegrationTest {
 
     @Autowired
     UserRepository userRepository;
@@ -49,10 +49,10 @@ class SignUpEventHandlerIntegrationTest extends BaseIntegrationTest {
     @DisplayName("회원가입 이벤트 발생 시, 공식 계정을 신규 회원의 친구로 등록한다")
     void test1() {
         //given
-        SignUpEvent signUpEvent = new SignUpEvent(user);
+        SignedUpEvent signedUpEvent = new SignedUpEvent(user);
 
         //when
-        transactionTemplate.executeWithoutResult(status -> applicationEventPublisher.publishEvent(signUpEvent));
+        transactionTemplate.executeWithoutResult(status -> applicationEventPublisher.publishEvent(signedUpEvent));
 
         //then
         softAssertions.assertThat(friendshipRepository.count()).isEqualTo(2);
@@ -64,11 +64,11 @@ class SignUpEventHandlerIntegrationTest extends BaseIntegrationTest {
     @DisplayName("회원가입이 실패한 경우, 발행된 회원가입 이벤트는 처리되지 않는다")
     void test2() {
         //given
-        SignUpEvent signUpEvent = new SignUpEvent(user);
+        SignedUpEvent signedUpEvent = new SignedUpEvent(user);
 
         //when
         transactionTemplate.executeWithoutResult(transactionStatus -> {
-            applicationEventPublisher.publishEvent(signUpEvent);
+            applicationEventPublisher.publishEvent(signedUpEvent);
             transactionStatus.setRollbackOnly();
         });
 

--- a/src/test/java/today/seasoning/seasoning/user/service/kakao/KakaoLoginServiceTest.java
+++ b/src/test/java/today/seasoning/seasoning/user/service/kakao/KakaoLoginServiceTest.java
@@ -26,7 +26,7 @@ import today.seasoning.seasoning.user.domain.User;
 import today.seasoning.seasoning.user.domain.UserRepository;
 import today.seasoning.seasoning.user.dto.LoginResult;
 import today.seasoning.seasoning.user.dto.SocialUserProfileDto;
-import today.seasoning.seasoning.user.event.SignUpEvent;
+import today.seasoning.seasoning.user.event.SignedUpEvent;
 
 @DisplayName("카카오 로그인 단위 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -82,11 +82,11 @@ class KakaoLoginServiceTest {
         assertThat(savedUser.getProfileImageUrl()).isEqualTo(newUserProfile.getProfileImageUrl());
 
         //then 2: 등록된 회원에 대한 회원가입 이벤트가 발행되어야 한다
-        ArgumentCaptor<SignUpEvent> publishedEventCaptor = ArgumentCaptor.forClass(SignUpEvent.class);
+        ArgumentCaptor<SignedUpEvent> publishedEventCaptor = ArgumentCaptor.forClass(SignedUpEvent.class);
         verify(eventPublisher).publishEvent(publishedEventCaptor.capture());
-        SignUpEvent publishedEvent = publishedEventCaptor.getValue();
+        SignedUpEvent publishedEvent = publishedEventCaptor.getValue();
 
-        assertThat(publishedEvent.getSignUpUser()).isEqualTo(newUser);
+        assertThat(publishedEvent.getSignedUpUser()).isEqualTo(newUser);
 
         //then 3: LoginResult.firstLogin의 값은 true이어야 한다
         assertThat(loginResult.isFirstLogin()).isTrue();
@@ -110,7 +110,7 @@ class KakaoLoginServiceTest {
         jwtUtil.verify(() -> JwtUtil.createToken(user.getId()));
 
         //then 2: 회원가입 이벤트는 발행되지 않아야 한다
-        verify(eventPublisher, never()).publishEvent(any(SignUpEvent.class));
+        verify(eventPublisher, never()).publishEvent(any(SignedUpEvent.class));
 
         //then 3: LoginResult.firstLogin의 값은 false이어야 한다
         assertThat(loginResult.isFirstLogin()).isFalse();


### PR DESCRIPTION
## 👷 작업한 내용
- 클래스 및 변수명을 과거시제로 변경: 이벤트 관련 클래스에는 과거시제를 사용하는 것이 일반적이다.
- 이벤트 핸들러를 관련 도메인 패키지로 이동(User -> Friendship) : 공식 계정을 신규 회원의 친구로 등록하는 핸들러이므로 Friendship 도메인의 기능이다